### PR TITLE
Update CI workflows and reduce duplicate runs

### DIFF
--- a/.github/workflows/ci-testpypi.yml
+++ b/.github/workflows/ci-testpypi.yml
@@ -53,7 +53,7 @@ jobs:
         id: bump-version
         run: |
           current_version=$(bump-my-version show-bump | awk 'NR==1 {print $1}')
-          new_versoin="${current_version}-$(date +%Y%m%d%H%M)"
+          new_versoin="${current_version}-$(date +%Y%m%d%H%M%S)"
           bump-my-version bump --verbose --no-commit --no-tag --new-version "${new_versoin}" suffix
           echo "NEW_VERSION=${new_versoin}" >> $GITHUB_OUTPUT
       - name: Build source and binary distributions

--- a/.github/workflows/ci-testpypi.yml
+++ b/.github/workflows/ci-testpypi.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   testpypi-py3-build-and-upload:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     outputs:
       NEW_VERSION: ${{ steps.bump-version.outputs.NEW_VERSION }}
     strategy:

--- a/.github/workflows/ci-testpypi.yml
+++ b/.github/workflows/ci-testpypi.yml
@@ -26,9 +26,27 @@ env:
   PROJECT_NAME_FOR_TESTPYPI: shadowsocks-manager-alexzhangs
 
 jobs:
+  check-run-history:
+    runs-on: ubuntu-latest
+    outputs:
+      RUN_HISTORY: ${{ steps.check-run.outputs.RUN_HISTORY }}
+    steps:
+      - name: Check run history
+        id: check-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_history=$(gh api repos/:owner/:repo/actions/workflows/ci-testpypi.yml/runs --jq '.workflow_runs[] | select(.event == "push" and .head_sha == "${{ github.sha }}") | .id' | wc -l)
+          echo "RUN_HISTORY=$run_history" >> $GITHUB_OUTPUT
+
   testpypi-py3-build-and-upload:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    needs: check-run-history
+    if: ${{ github.event_name == 'workflow_dispatch'
+            || github.event_name == 'push'
+            || (github.event_name == 'workflow_run' 
+                && github.event.workflow_run.conclusion == 'success' 
+                && needs.check-run-history.outputs.RUN_HISTORY == '0') }}
     outputs:
       NEW_VERSION: ${{ steps.bump-version.outputs.NEW_VERSION }}
     strategy:

--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -18,6 +18,8 @@ on:
       - 'shadowsocks_manager/**'
       - '!shadowsocks_manager/uwsgi.ini'
   pull_request:
+    branches:
+      - master
   schedule:
     - cron: '23 11 1 * *'
 


### PR DESCRIPTION
The `ci-testpypi.yml` workflow now includes a step to check the run history and only run if there are no previous runs for the same commit. 

The `ci-unittest.yml` workflow has been updated to include the `master` branch in the `pull_request` event.