### PR TITLE
Refactor domain models and update CLI commands

### DIFF
--- a/.ssm-env-example
+++ b/.ssm-env-example
@@ -19,11 +19,11 @@ SSM_TIME_ZONE=UTC
 
 # Django settings, used as (presudo code):
 #   ALLOWED_HOSTS += SSM_ALLOWED_SITES_DEFAULTS.split(',')
-SSM_ALLOWED_SITES_DEFAULTS
+SSM_ALLOWED_SITES_DEFAULTS=
 
 # Django settings, used as (presudo code):
 #   ALLOWED_HOSTS += SSM_ALLOWED_SITES_DEFAULTS_PLUS.split(',')
-SSM_ALLOWED_SITES_DEFAULTS_PLUS
+SSM_ALLOWED_SITES_DEFAULTS_PLUS=
 
 # Django settings, used as (presudo code):
 #   ALLOWED_HOSTS += {dyanmic_public_ip} if SSM_ALLOWED_SITES_DYNAMIC_PUBLIC_IP else []

--- a/.ssm-env-example
+++ b/.ssm-env-example
@@ -17,6 +17,26 @@ SSM_DEBUG=True
 #   TIME_ZONE = SSM_TIME_ZONE
 SSM_TIME_ZONE=UTC
 
+# Django settings, used as (presudo code):
+#   ALLOWED_HOSTS += SSM_ALLOWED_SITES_DEFAULTS.split(',')
+SSM_ALLOWED_SITES_DEFAULTS
+
+# Django settings, used as (presudo code):
+#   ALLOWED_HOSTS += SSM_ALLOWED_SITES_DEFAULTS_PLUS.split(',')
+SSM_ALLOWED_SITES_DEFAULTS_PLUS
+
+# Django settings, used as (presudo code):
+#   ALLOWED_HOSTS += {dyanmic_public_ip} if SSM_ALLOWED_SITES_DYNAMIC_PUBLIC_IP else []
+SSM_ALLOWED_SITES_DYNAMIC_PUBLIC_IP=False
+
+# Django settings for CachedAllowedSites, used as:
+#   CachedAllowedSites.net_timeout = SSM_ALLOWED_SITES_NET_TIMEOUT
+SSM_ALLOWED_SITES_NET_TIMEOUT=5
+
+# Django settings for CachedAllowedSites, used as:
+#   CachedAllowedSites.cache_timeout = SSM_ALLOWED_SITES_CACHE_TIMEOUT
+SSM_ALLOWED_SITES_CACHE_TIMEOUT=180
+
 # Django settings, used as:
 #   CACHES.default.location = SSM_MEMCACHED_HOST:SSM_MEMCACHED_PORT
 SSM_MEMCACHED_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -204,10 +204,6 @@ So either you get some change on your own or stick with the libev edition.
 
 ## 7. Known Issues
 
-1. DNS records matching for Node may not be accurate on macOS.
-    For unknown reason sometimes DNS query returns only one IP address
-while multiple IP addresses were configured for the domain.
-
 1. The Shadowsocks Python edition's ssserver won't start on macOS.
     The error message is like:
     ```
@@ -292,6 +288,15 @@ while multiple IP addresses were configured for the domain.
     ```sh
     brew install openssl@1.1
     ```
+
+1. Domain record is not synced into DNS provider as expected.
+
+    There might be a conflict record in the DNS provider. For example, a record with the same name but different type, such as CNAME.
+    The sync process will be limited to the records with same type and name, it won't touched any other records.
+
+    Solution:
+    1. Remove the conflict record from the DNS provider by yourself.
+    1. Run the sync process again.
 
 
 ## 8. Development

--- a/bin/ssm-setup.sh
+++ b/bin/ssm-setup.sh
@@ -42,6 +42,34 @@
 #?     The value can be any valid timezone name.
 #?     The default value depends on the .ssm-env file and Django's settings.
 #?
+#?   - SSM_ALLOWED_SITES_DEFAULTS
+#?
+#?     Set the default allowed sites for the shadowsocks-manager.
+#?     The value can be any valid domain name and ip address, separated by comma.
+#?     The default value depends on the .ssm-env file and Django's settings.
+#?
+#?   - SSM_ALLOWED_SITES_DEFAULTS_PLUS
+#?
+#?     Set the additional allowed sites for the shadowsocks-manager.
+#?     The value can be any valid domain name and ip address, separated by comma.
+#?     The default value depends on the .ssm-env file and Django's settings.
+#?
+#?   - SSM_ALLOWED_SITES_DYNAMIC_PUBLIC_IP
+#?
+#?     If set True, the server's public IP address is set for ALLOWED_HOSTS at runtime.
+#?     The value can be 'True' or 'False'.
+#?     The default value depends on the .ssm-env file and Django's settings.
+#?
+#?   - SSM_ALLOWED_SITES_NET_TIMEOUT
+#?
+#?     Set the timeout (in seconds) for the network request to get the server's public IP address.
+#?     The default value depends on the .ssm-env file and Django's settings.
+#?
+#?   - SSM_ALLOWED_SITES_CACHE_TIMEOUT
+#?
+#?     Set the cache timeout (in seconds) for the site.domain and server's public IP address.
+#?     The default value depends on the .ssm-env file and Django's settings.
+#?
 #?   - SSM_MEMCACHED_HOST, SSM_MEMCACHED_PORT
 #?
 #?     Set the Memcached server's host and port which are used by Django cache.

--- a/bin/ssm-setup.sh
+++ b/bin/ssm-setup.sh
@@ -290,10 +290,10 @@ function main () {
 
     if [[ -n $domain ]]; then
         ssm-manage domain_domain --name "$domain" --nameserver "$dns_name"
-        ssm-manage domain_site --name "shadowsocks-manager" --domain "$domain"
+        ssm-manage domain_site --domain "$domain"
 
         if [[ -n $type && -n $answer ]]; then
-            ssm-manage domain_record --fqdn "$domain" --type "$type" --answer "$answer" --site "shadowsocks-manager"
+            ssm-manage domain_record --fqdn "$domain" --type "$type" --answer "$answer" --site
         fi
     fi
 }

--- a/bin/ssm-setup.sh
+++ b/bin/ssm-setup.sh
@@ -253,16 +253,16 @@ function main () {
         ssm-dotenv -w "${envs[@]}"
     fi
 
-    if [[ -n $collect_flag ]]; then
+    if [[ $collect_flag -eq 1 ]]; then
         ssm-manage collectstatic --no-input -c
     fi
 
-    if [[ -n $migrate_flag ]]; then
+    if [[ $migrate_flag -eq 1 ]]; then
         ssm-manage makemigrations
         ssm-manage migrate
     fi
 
-    if [[ -n $loaddata_flag ]]; then
+    if [[ $loaddata_flag -eq 1 ]]; then
         ssm-manage loaddata fixtures/auth.group.json \
                fixtures/sites.site.json \
                fixtures/django_celery_beat.crontabschedule.json \
@@ -290,9 +290,10 @@ function main () {
 
     if [[ -n $domain ]]; then
         ssm-manage domain_domain --name "$domain" --nameserver "$dns_name"
+        ssm-manage domain_site --name "shadowsocks-manager" --domain "$domain"
 
         if [[ -n $type && -n $answer ]]; then
-            ssm-manage domain_record --fqdn "$domain" --type "$type" --answer "$answer" --site
+            ssm-manage domain_record --fqdn "$domain" --type "$type" --answer "$answer" --site "shadowsocks-manager"
         fi
     fi
 }

--- a/deploy/nginx/sites-available/ssm-https.conf
+++ b/deploy/nginx/sites-available/ssm-https.conf
@@ -5,9 +5,8 @@
         listen      80;
         listen      [::]:80;
 
-        location / {
-            return 301 https://$host$request_uri;
-        }
+        # include common block
+        include includes/ssm-server-common.conf;
     }
 
     server {

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -242,26 +242,29 @@ function main () {
     declare domain dns_env https_flag=0 \
             OPTIND OPTARG opt
 
-    # ignoring the unknown options
-    while getopts :d:E:Sh opt; do
-        case $opt in
-            d)
-                domain=$OPTARG
-                ;;
-            E)
-                dns_env=$OPTARG
-                ;;
-            S)
-                https_flag=1
-                ;;
-            h)
-                usage
-                return
-                ;;
-            *)
-                # ignored as they are processed by the docker-ssm-setup.sh
-                ;;
-        esac
+    # Combine the outer while loop and the leading colon to ignore the unknown options
+    while [[ $OPTIND -le $# ]]; do
+        while getopts :d:E:Sh opt; do
+            case $opt in
+                d)
+                    domain=$OPTARG
+                    ;;
+                E)
+                    dns_env=$OPTARG
+                    ;;
+                S)
+                    https_flag=1
+                    ;;
+                h)
+                    usage
+                    return
+                    ;;
+                *)
+                    # ignored as they are processed by the docker-ssm-setup.sh
+                    ;;
+            esac
+        done
+        ((OPTIND++))
     done
 
     if [[ $# -eq 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -120,10 +120,13 @@ function main () {
     # run rabbitmq, used by celery
     docker run --restart=always -d --network "$ssm_network_name" --name "$rabbitmq_container_name" rabbitmq
 
-    # run shadowsocks-manager
+    # run shadowsocks-manager wihtout --detach in background
     echo "Running $ssm_container_name ..."
-    docker run --restart=always -d -p 80:80 -p 443:443 --network "$ssm_network_name" -v "$ssm_volume_path:/var/local/ssm" \
-        --name "$ssm_container_name" "$ssm_image" "${default_options[@]}" "$@"
+    docker run --restart=always -p 80:80 -p 443:443 --network "$ssm_network_name" -v "$ssm_volume_path:/var/local/ssm" \
+        --name "$ssm_container_name" "$ssm_image" "${default_options[@]}" "$@" &
+
+    # wait for the shadowsocks-manager to start
+    wait
 }
 
 main "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     # 20240602 - py3.12 - v4.0.7 - import ERROR: module 'django.utils.formats' has no attribute 'sanitize_strftime_format'
     # 20240602 - py3.12 - v4.0.0 - export ERROR: AttributeError: 'AccountAdmin' object has no attribute 'search_help_text': File import_export/admin.py, line 670: changelist_kwargs["search_help_text"] = self.search_help_text
     # "django-import-export",
-    "django-import-export==3.3.9; python_version >= '3.8'",
+    "django-import-export<=3.3.9",
 
     "djangorestframework",
     "dns-lexicon[full]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,11 @@ dependencies = [
     "django-filter~=1.1; python_version <= '2.7'",
     "django-filter; python_version > '2.7'",
 
-    "django-import-export",
+    # 20240602 - py3.12 - v4.0.7 - import ERROR: module 'django.utils.formats' has no attribute 'sanitize_strftime_format'
+    # 20240602 - py3.12 - v4.0.0 - export ERROR: AttributeError: 'AccountAdmin' object has no attribute 'search_help_text': File import_export/admin.py, line 670: changelist_kwargs["search_help_text"] = self.search_help_text
+    # "django-import-export",
+    "django-import-export==3.3.9; python_version > '2.7'",
+
     "djangorestframework",
     "dns-lexicon[full]",
     "dnspython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     # 20240602 - py3.12 - v4.0.7 - import ERROR: module 'django.utils.formats' has no attribute 'sanitize_strftime_format'
     # 20240602 - py3.12 - v4.0.0 - export ERROR: AttributeError: 'AccountAdmin' object has no attribute 'search_help_text': File import_export/admin.py, line 670: changelist_kwargs["search_help_text"] = self.search_help_text
     # "django-import-export",
-    "django-import-export==3.3.9; python_version > '2.7'",
+    "django-import-export==3.3.9; python_version >= '3.8'",
 
     "djangorestframework",
     "dns-lexicon[full]",

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ install_requires =
     # 20240602 - py3.12 - v4.0.7 - import ERROR: module 'django.utils.formats' has no attribute 'sanitize_strftime_format'
     # 20240602 - py3.12 - v4.0.0 - export ERROR: AttributeError: 'AccountAdmin' object has no attribute 'search_help_text': File import_export/admin.py, line 670: changelist_kwargs["search_help_text"] = self.search_help_text
     # django-import-export
-    django-import-export==3.3.9; python_version >= '3.8'
+    django-import-export<=3.3.9
 
     djangorestframework
     dns-lexicon[full]

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,11 @@ install_requires =
     django-filter~=1.1; python_version <= '2.7'
     django-filter; python_version > '2.7'
 
-    django-import-export
+    # 20240602 - py3.12 - v4.0.7 - import ERROR: module 'django.utils.formats' has no attribute 'sanitize_strftime_format'
+    # 20240602 - py3.12 - v4.0.0 - export ERROR: AttributeError: 'AccountAdmin' object has no attribute 'search_help_text': File import_export/admin.py, line 670: changelist_kwargs["search_help_text"] = self.search_help_text
+    # django-import-export
+    django-import-export==3.3.9; python_version > '2.7'
+
     djangorestframework
     dns-lexicon[full]
     dnspython

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ install_requires =
     # 20240602 - py3.12 - v4.0.7 - import ERROR: module 'django.utils.formats' has no attribute 'sanitize_strftime_format'
     # 20240602 - py3.12 - v4.0.0 - export ERROR: AttributeError: 'AccountAdmin' object has no attribute 'search_help_text': File import_export/admin.py, line 670: changelist_kwargs["search_help_text"] = self.search_help_text
     # django-import-export
-    django-import-export==3.3.9; python_version > '2.7'
+    django-import-export==3.3.9; python_version >= '3.8'
 
     djangorestframework
     dns-lexicon[full]

--- a/shadowsocks_manager/domain/admin.py
+++ b/shadowsocks_manager/domain/admin.py
@@ -68,11 +68,11 @@ class RecordAdmin(admin.ModelAdmin):
     is_matching_dns_query.boolean = True
     is_matching_dns_query.short_description = 'DNS Query'
 
-    def sync_to_dns(self, request, queryset):
+    def dns_sync(self, request, queryset):
         for obj in queryset:
-            result = obj.sync_to_dns()
-            messages.info(request, '{0}: {1}'.format(obj.host, json.dumps(result)))
+            result = obj.dns_sync()
+            messages.info(request, '{0}: {1}'.format(obj.fqdn, json.dumps(result)))
 
-    sync_to_dns.short_description = 'Synchronize DNS records to DNS server for Selected Domain'
+    dns_sync.short_description = 'Synchronize DNS records to DNS server for Selected Domain'
 
-    actions = (sync_to_dns,)
+    actions = (dns_sync,)

--- a/shadowsocks_manager/domain/management/commands/domain_site.py
+++ b/shadowsocks_manager/domain/management/commands/domain_site.py
@@ -1,28 +1,31 @@
 from django.core.management.base import BaseCommand
+from django.conf import settings
 from domain.models import Site
 
 class Command(BaseCommand):
-    help = 'Create or update domain.models.Site'
+    help = 'Create or update the active django.contrib.sites.models.Site'
     django_default_options = ('verbosity', 'settings', 'pythonpath', 'traceback', 'no_color', 
                        'force_color', 'skip_checks')
 
     def add_arguments(self, parser):
-        parser.add_argument('--name', required=True,
-                            help='Site name.')
+        parser.add_argument('--name', type=str, nargs='?',
+                            help='Site name. Required for creating a new site.'
+                            'If this option is not set, the field will remain unchanged in update.'
+                            'If this options is set with an empty value, the field will be'
+                            'set or updated to blank.')
         parser.add_argument('--domain', type=str, nargs='?',
-                            help='Site domain. If this option is not set or set '
-                            'with an empty value, the domain field will be set or '
-                            'updated to blank.')
+                            help='Site domain. Required for creating a new site.'
+                            'If this option is not set, the field will remain unchanged in update.'
+                            'If this options is set with an empty value, the field will be'
+                            'set or updated to blank.')
 
     def handle(self, *args, **options):
         fields = self.get_fields(options)
 
-        # Site.domain accepts blank value but NULL value is not allowed
-        if fields['domain'] is None:
-            fields['domain'] = ''
+        fields = {key: value for key, value in fields.items() if value is not None}
 
-        site, created = Site.objects.update_or_create(name=fields['name'], defaults=fields)
-        self.stdout.write(self.style.SUCCESS('Successfully {0} site {1} with domain: {2}'.format('created' if created else 'updated', fields['name'], fields['domain'] or 'blank')))
+        site, created = Site.objects.update_or_create(pk=settings.SITE_ID, defaults=fields)
+        self.stdout.write(self.style.SUCCESS('Successfully {0} site {1} with: {2}'.format('created' if created else 'updated', site.id, fields)))
 
     @classmethod
     def get_fields(cls, options):

--- a/shadowsocks_manager/domain/management/commands/domain_site.py
+++ b/shadowsocks_manager/domain/management/commands/domain_site.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+from domain.models import Site
+
+class Command(BaseCommand):
+    help = 'Create or update domain.models.Site'
+    django_default_options = ('verbosity', 'settings', 'pythonpath', 'traceback', 'no_color', 
+                       'force_color', 'skip_checks')
+
+    def add_arguments(self, parser):
+        parser.add_argument('--name', required=True,
+                            help='Site name.')
+        parser.add_argument('--domain', type=str, nargs='?',
+                            help='Site domain. If this option is not set or set '
+                            'with an empty value, the domain field will be set or '
+                            'updated to blank.')
+
+    def handle(self, *args, **options):
+        fields = self.get_fields(options)
+
+        # Site.domain accepts blank value but NULL value is not allowed
+        if fields['domain'] is None:
+            fields['domain'] = ''
+
+        site, created = Site.objects.update_or_create(name=fields['name'], defaults=fields)
+        self.stdout.write(self.style.SUCCESS('Successfully {0} site {1} with domain: {2}'.format('created' if created else 'updated', fields['name'], fields['domain'] or 'blank')))
+
+    @classmethod
+    def get_fields(cls, options):
+        return {key: value for key, value in options.items() if key not in cls.django_default_options}

--- a/shadowsocks_manager/domain/models.py
+++ b/shadowsocks_manager/domain/models.py
@@ -239,8 +239,8 @@ class Record(models.Model):
     host = models.CharField(max_length=64,
         help_text='Host name without domain name. Example: `vpn`.')
     domain = models.ForeignKey(Domain, on_delete=models.PROTECT)
-    type = models.CharField(max_length=8, null=True, blank=True, choices=TYPE)
-    answer = models.CharField(max_length=512, null=True, blank=True,
+    type = models.CharField(max_length=8, choices=TYPE)
+    answer = models.CharField(max_length=512,
         help_text='Answer for the host name, comma "," is the delimiter for multiple answers.')
     site = models.ForeignKey(Site, null=True, blank=True, on_delete=models.SET_NULL, related_name='records',
         help_text="The record with a site will be dynamically added to Django's ALLOWED_HOSTS.")

--- a/shadowsocks_manager/domain/models.py
+++ b/shadowsocks_manager/domain/models.py
@@ -73,6 +73,9 @@ class Site(Site):
     def __str__(self):
         return self.name
 
+    def save(self, *args, **kwargs):
+        super(Site, self).save(*args, **kwargs)
+        settings.ALLOWED_HOSTS.update_cache()
 
 class DnsApi:
     """
@@ -242,7 +245,6 @@ class Record(models.Model):
         if self.site:
             self.site.domain = self.fqdn
             self.site.save()
-            settings.ALLOWED_HOSTS.update_cache()
 
     def auto_resolve(self):
         """

--- a/shadowsocks_manager/domain/serializers.py
+++ b/shadowsocks_manager/domain/serializers.py
@@ -24,7 +24,7 @@ class RecordSerializer(serializers.ModelSerializer):
         model = models.Record
         fields = ('id', 'fqdn', 'host', 'domain', 'type', 'answer', 'site', 'dt_created', 'dt_updated')
         extra_kwargs = {
-            'fqdn': {'required': False, 'allow_null': True, 'allow_blank': True},
-            'host': {'required': False, 'allow_null': True, 'allow_blank': True},
-            'domain': {'required': False, 'allow_null': True},
+            'fqdn': {'required': False, 'allow_null': True, 'default': None},
+            'host': {'required': False, 'allow_null': True, 'default': None},
+            'domain': {'required': False, 'allow_null': True, 'default': None},
         }

--- a/shadowsocks_manager/shadowsocks/fixtures/config.json
+++ b/shadowsocks_manager/shadowsocks/fixtures/config.json
@@ -1,1 +1,1 @@
-[{"model": "shadowsocks.config", "pk": 1, "fields": {"port_begin": 8381, "port_end": 8480, "timeout_remote": 3, "timeout_local": 0.5, "cache_timeout": 300, "dt_created": "2019-05-03T19:03:55.716Z", "dt_updated": "2019-05-16T17:11:38.233Z"}}]
+[{"model": "shadowsocks.config", "pk": 1, "fields": {"port_begin": 8381, "port_end": 8385, "timeout_remote": 3, "timeout_local": 0.5, "cache_timeout": 300, "dt_created": "2019-05-03T19:03:55.716Z", "dt_updated": "2019-05-16T17:11:38.233Z"}}]

--- a/shadowsocks_manager/shadowsocks/tests.py
+++ b/shadowsocks_manager/shadowsocks/tests.py
@@ -139,7 +139,6 @@ class ConfigTestCase(AppTestCase):
     @classmethod
     def up(cls):
         obj = models.Config.load()
-        obj.port_end=8385
         obj.timeout_local=0.3
         obj.timeout_remote=1  # minimal the waiting time with mock public ip address
         obj.save()
@@ -160,7 +159,6 @@ class AccountTestCase(AppTestCase):
     @classmethod
     def up(cls):
         config = models.Config.load()
-        config.port_end=8385
 
         # generate 2 accounts
         for port in [config.port_begin, config.port_end]:

--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -210,11 +210,9 @@ LOGGING = {
             'class': 'logging.StreamHandler',
         },
     },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': 'INFO',
-        },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
     },
 }
 

--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -47,12 +47,23 @@ DEBUG = config('SSM_DEBUG', default=True, cast=bool)
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+# set ALLOWED_HOSTS
+ALLOWED_SITES_DEFAULTS = config('SSM_ALLOWED_SITES_DEFAULTS', default='localhost,127.0.0.1')
+ALLOWED_SITES_DEFAULTS = {item.lower() for item in ALLOWED_SITES_DEFAULTS.split(',') if item}
+
+ALLOWED_SITES_DEFAULTS_PLUS = config('SSM_ALLOWED_SITES_DEFAULTS_PLUS', default='')
+ALLOWED_SITES_DEFAULTS_PLUS = {item.lower() for item in ALLOWED_SITES_DEFAULTS_PLUS.split(',') if item}
+
+ALLOWED_SITES_DYNAMIC_PUBLIC_IP = config('SSM_ALLOWED_SITES_DYNAMIC_PUBLIC_IP', default=False, cast=bool)
+ALLOWED_SITES_NET_TIMEOUT = config('SSM_ALLOWED_SITES_NET_TIMEOUT', default=5, cast=int)
+ALLOWED_SITES_CACHE_TIMEOUT = config('SSM_ALLOWED_SITES_CACHE_TIMEOUT', default=180, cast=int)
+
 from allowedsites import CachedAllowedSites
 ALLOWED_HOSTS = CachedAllowedSites(
-    defaults=('localhost', '127.0.0.1',),
-    dynamic_public_ip=True,
-    net_timeout=3,
-    cache_timeout=30
+    defaults=ALLOWED_SITES_DEFAULTS.union(ALLOWED_SITES_DEFAULTS_PLUS),
+    dynamic_public_ip=ALLOWED_SITES_DYNAMIC_PUBLIC_IP,
+    net_timeout=ALLOWED_SITES_NET_TIMEOUT,
+    cache_timeout=ALLOWED_SITES_CACHE_TIMEOUT,
 )
 
 # set the SITE_ID, make sure there's a fixture for the site

--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -55,6 +55,7 @@ ALLOWED_HOSTS = CachedAllowedSites(
     cache_timeout=30
 )
 
+# set the SITE_ID, make sure there's a fixture for the site
 SITE_ID = 1
 
 

--- a/shadowsocks_manager/utils/dotenv.py
+++ b/shadowsocks_manager/utils/dotenv.py
@@ -77,12 +77,12 @@ def main():
                 if line.startswith(key + '='):
                     f.write(new_line)
                     key_found = True
-                    print("Updated environment variable '{0}' in .ssm-env file.".format(key))
+                    print("Updated environment variable '{0}' in '{1}'.".format(key, env_file))
                 else:
                     f.write(line)
             if not key_found:
                 f.write('\n' + new_line)
-                print("Added environment variable '{0}' to .ssm-env file.".format(key))
+                print("Added environment variable '{0}' to '{1}'.".format(key, env_file))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes several changes to the codebase:

- Refactoring of the domain/models.py file

- Updating the default port_end in the fixture and test case

- Updating the cli command: domain_record

- Adding the cli command: domain_site

- Fixing defects in the ssm-setup.sh and docker-entrypoint.sh files

- Updating the install.sh and ssm-https.conf files

- Enhancing the Record model and RecordSerializer in domain/serializers.py

These changes improve the functionality and maintainability of the codebase.