### PR TITLE
Hotfix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,5 +17,4 @@ dist
 .tox
 *.sh
 _config.yml
-.git
 .github

--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -17,6 +17,8 @@ on:
       - 'bin/**'
       - 'shadowsocks_manager/**'
       - '!shadowsocks_manager/uwsgi.ini'
+    tags-ignore:
+      - "**"
   pull_request:
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![GitHub Actions - CI PyPI](https://github.com/alexzhangs/shadowsocks-manager/actions/workflows/ci-pypi.yml/badge.svg)](https://github.com/alexzhangs/shadowsocks-manager/actions/workflows/ci-pypi.yml)
 [![PyPI Package Version](https://badge.fury.io/py/shadowsocks-manager.svg)](https://pypi.org/project/shadowsocks-manager/)
 [![codecov](https://codecov.io/gh/alexzhangs/shadowsocks-manager/graph/badge.svg?token=KTI3TNRKAV)](https://codecov.io/gh/alexzhangs/shadowsocks-manager)
+[![CodeFactor](https://www.codefactor.io/repository/github/alexzhangs/shadowsocks-manager/badge)](https://www.codefactor.io/repository/github/alexzhangs/shadowsocks-manager)
 
 [![GitHub Actions - CI Docker Build and Push](https://github.com/alexzhangs/shadowsocks-manager/actions/workflows/ci-docker.yml/badge.svg?event=release)](https://github.com/alexzhangs/shadowsocks-manager/actions/workflows/ci-docker.yml)
 [![Docker Image Version](https://img.shields.io/docker/v/alexzhangs/shadowsocks-manager?label=docker%20image)](https://hub.docker.com/r/alexzhangs/shadowsocks-manager)

--- a/bin/ssm-dev-start.sh
+++ b/bin/ssm-dev-start.sh
@@ -35,7 +35,7 @@ function main () {
     ssm-celery -A shadowsocks_manager worker -l "${SSM_DEV_CELERY_LOG_LEVEL:info}" -B &
     # don't quote the variable $listen, leave it this way on purpose
     # shellcheck disable=SC2086
-    ssm-manage runserver $listen --insecure
+    ssm-manage runserver --insecure $listen
 }
 
 main "$@"

--- a/docker-build-and-run.sh
+++ b/docker-build-and-run.sh
@@ -130,14 +130,15 @@ function main () {
         shift
     done
 
-    # shift off the '--' delimiter
-    if [[ $# -gt 0 && $1 == "--" ]]; then
-        shift
+    if [[ $# -gt 0 ]]; then
+        # shift off the '--' delimiter
+        if [[ $1 == "--" ]]; then
+            shift
+        fi
+        # The rest are docker run cmd options
+        run_cmd_opts=("$@")
         run_flag=1
     fi
-
-    # The rest are docker run cmd options
-    run_cmd_opts=("$@")
 
     # default distributions
     # shellcheck disable=SC2206

--- a/docker-build-and-run.sh
+++ b/docker-build-and-run.sh
@@ -198,7 +198,7 @@ function main () {
 
     declare dist image_tag image container
     for dist in "${distributions[@]}"; do
-        image_tag=$dist-dev-$(date +%Y%m%d-%H%M)
+        image_tag=$dist-dev-$(date -u +%Y%m%d-%H%M)
         image="$image_name:$image_tag"
         container="ssm-$image_tag"
         BUILD_OPTS=( "${build_opts[@]}" -t "$image" -f "$script_dir/docker/$dist/Dockerfile" . )

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -40,6 +40,8 @@ ARG http_proxy https_proxy all_proxy
 
 # Install supervisor nginx
 RUN apk --no-cache add supervisor nginx \
+        # used by shadowsocks-manager
+        git \
         # used by uwsgi
         gcc linux-headers libc-dev \
         # used by cffi
@@ -90,8 +92,14 @@ RUN chmod +x docker/*.sh
 RUN mkdir -p "${SSM_DATA_HOME}"
 VOLUME [ "${SSM_DATA_HOME}" ]
 
+# overcome the git check: fatal: detected dubious ownership in repository at '/shadowsocks-manager'
+RUN git config --global --add safe.directory "$(pwd)"
+
 # Install shadowsocks-manager
 RUN pip install --no-cache-dir -e . && chown -R ${SSM_USER}:${SSM_USER} .
+
+# Set the build number
+RUN ssm-version --set-build
 
 # Expose the nginx port
 EXPOSE 80 443

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -87,8 +87,14 @@ RUN chmod +x docker/*.sh
 RUN mkdir -p "${SSM_DATA_HOME}"
 VOLUME [ "${SSM_DATA_HOME}" ]
 
+# overcome the git check: fatal: detected dubious ownership in repository at '/shadowsocks-manager'
+RUN git config --global --add safe.directory "$(pwd)"
+
 # Install shadowsocks-manager
 RUN pip install --no-cache-dir -e . && chown -R ${SSM_USER}:${SSM_USER} .
+
+# Set the build number
+RUN ssm-version --set-build
 
 # Expose the nginx port
 EXPOSE 80 443

--- a/docker/slim/Dockerfile
+++ b/docker/slim/Dockerfile
@@ -41,6 +41,8 @@ ARG http_proxy https_proxy all_proxy
 # Install supervisor nginx
 RUN apt-get update && \
     apt-get install -y supervisor nginx \
+        # used by shadowsocks-manager
+        git \
         # ps, netstat
         procps net-tools \
         # gcc is used by uwsgi
@@ -91,6 +93,12 @@ VOLUME [ "${SSM_DATA_HOME}" ]
 
 # Install shadowsocks-manager
 RUN pip install --no-cache-dir -e . && chown -R ${SSM_USER}:${SSM_USER} .
+
+# overcome the git check: fatal: detected dubious ownership in repository at '/shadowsocks-manager'
+RUN git config --global --add safe.directory "$(pwd)"
+
+# Set the build number
+RUN ssm-version --set-build
 
 # Expose the nginx port
 EXPOSE 80 443

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ ssm-manage = "shadowsocks_manager.utils.manage:main"
 ssm-uwsgi = "shadowsocks_manager.utils.uwsgi:main"
 ssm-celery = "shadowsocks_manager.utils.celery_app:main"
 ssm-dotenv = "shadowsocks_manager.utils.dotenv:main"
+ssm-version = "shadowsocks_manager.utils.version:main"
 
 [tool.setuptools]
 script-files = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ dependencies = [
     "uWSGI",
 ]
 optional-dependencies.test = [
+    "mock; python_version <= '2.7'",
     "coverage[toml]; python_version >= '2.7' and python_version < '3.11'",
     "coverage; python_version >= '3.11'",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,3 +139,4 @@ console_scripts =
     ssm-uwsgi = shadowsocks_manager.utils.uwsgi:main
     ssm-celery = shadowsocks_manager.utils.celery_app:main
     ssm-dotenv = shadowsocks_manager.utils.dotenv:main
+    ssm-version = shadowsocks_manager.utils.version:main

--- a/shadowsocks_manager/__main__.py
+++ b/shadowsocks_manager/__main__.py
@@ -19,11 +19,11 @@ def main():
         Make the proxy call after adding the django root to the python path and changing the current directory to the django root.
 
     Usage:
-        ssm COMMAND [OPTIONS]
+        ssm <COMMAND> [<ARGS> ...]
 
     Options:
         COMMAND     The command to be run.
-        OPTIONS     All options are transparently passing to the called command.
+        ARGS        All arguments are transparently passing to the called command.
 
     Returns:
         None
@@ -33,7 +33,7 @@ def main():
         $ ssm uwsgi --ini uwsgi.ini
         $ ssm celery -A shadowsocks_manager worker -l info
     """
-    #docopt(main.__doc__)
+    docopt(main.__doc__, options_first=True)
 
     django_root = os.path.dirname(os.path.abspath(__file__))
 
@@ -43,7 +43,6 @@ def main():
 
     # change dir to the django root to allow the dir-sensitive commands(such as loaddata) to be run from any directory
     os.chdir(django_root)
-
 
     # make the proxy call
     return subprocess.call(sys.argv[1:])

--- a/shadowsocks_manager/dynamicmethod/views.py
+++ b/shadowsocks_manager/dynamicmethod/views.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-# py2.7 and py3 compatibility imports
-from __future__ import unicode_literals
-
-from django.shortcuts import render
-
-# Create your views here.

--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -277,7 +277,7 @@ LOGGING = {
 
 # Memcached
 
-CACHES_BACKEND = config('SSM_CACHE_BACKEND', default='locmem.LocMemCache')
+CACHES_BACKEND = config('SSM_CACHES_BACKEND', default='locmem.LocMemCache')
 MEMCACHED_HOST = config('SSM_MEMCACHED_HOST', default='localhost')
 MEMCACHED_PORT = config('SSM_MEMCACHED_PORT', default='11211')
 

--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -16,47 +16,8 @@ from __future__ import unicode_literals
 import os
 from decouple import Config, RepositoryEnv
 
-from . import __version__, __build__
+from utils.version import get_version
 
-
-def get_git_build():
-    """
-    Get the build number from the git repository.
-
-    build number format: {short_hash}[-{timestamp}]
-        - short_hash:   the short hash of the commit
-        - timestamp:    the timestamp of the build, which is appended if the working directory is dirty
-    """
-    try:
-        import subprocess
-
-        # get the build information from git commit
-        build = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], cwd=PROJECT_ROOT).strip().decode('utf-8')
-
-        # if the working directory is dirty, append timestamp to the build information
-        if subprocess.check_output(['git', 'status', '--porcelain'], cwd=PROJECT_ROOT).strip():
-            return '{}-{}'.format(build, subprocess.check_output(['date', '+%Y%m%d-%H%M']).strip().decode('utf-8'))
-    except Exception:
-        return ''
-        
-    
-def get_full_version():
-    """
-    Get the full version of the package.
-
-    full version format: v{version}-{build}
-        - version:  the package version
-            - The package.__version__ is always hornored.
-            - The package building process should be responsible for updating the package.__version__.
-            - For dev environment, merging the master branch back should update the package.__version__.
-        - build:    the package build number
-            - First try to get the build number from the git repository (for dev environment).
-            - If failed fall back to use the package.__build__ (for package distribution).
-            - The package building process should be responsible for updating the package.__build__.
-    """
-    version = __version__
-    build = get_git_build() or __build__
-    return 'v{}-{}'.format(version, build) if build else 'v{}'.format(version)
 
 def get_env_file(ssm_data_home):
     env_file = os.path.join(ssm_data_home, '.ssm-env')
@@ -83,7 +44,8 @@ if not os.path.exists(DATA_HOME):
 config = Config(RepositoryEnv(get_env_file(DATA_HOME)))
 
 # get the full version
-VERSION = get_full_version()
+VERSION = get_version(full=True)
+print('shadowsocks-manager [{}]: VERSION: {}'.format(os.getpid(), VERSION))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/

--- a/shadowsocks_manager/shadowsocks_manager/urls.py
+++ b/shadowsocks_manager/shadowsocks_manager/urls.py
@@ -19,12 +19,12 @@ from __future__ import unicode_literals
 
 from django.conf.urls import url, include
 from django.contrib import admin
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.conf import settings
 
 
 admin.site.site_title = "Shadowsocks Manager"
-admin.site.site_header = mark_safe('Shadowsocks Manager Administration <span style="font-size: x-small">{}</span>'.format(settings.VERSION))
+admin.site.site_header = format_html('Shadowsocks Manager Administration <span style="font-size: x-small">{}</span>'.format(settings.VERSION))
 admin.site.index_title = "Administration"
 
 urlpatterns = [

--- a/shadowsocks_manager/singleton/views.py
+++ b/shadowsocks_manager/singleton/views.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-# py2.7 and py3 compatibility imports
-from __future__ import unicode_literals
-
-from django.shortcuts import render
-
-# Create your views here.

--- a/shadowsocks_manager/utils/manage.py
+++ b/shadowsocks_manager/utils/manage.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+from docopt import docopt
 import signal
 
 
@@ -15,10 +16,10 @@ signal.signal(signal.SIGINT, signal_handler)
 def main():
     """
     Description:
-        Call `ssm python manage.py` and proxy the rest options.
+        Call `ssm python manage.py` and proxy all the arguments.
 
     Usage:
-        ssm DJANGO_COMMAND [OPTIONS]
+        ssm-manage <DJANGO_COMMAND> [<OPTIONS> ...]
 
     Options:
         DJANGO_COMMAND     The django management command to be run.
@@ -31,6 +32,7 @@ def main():
         $ ssm-manage runserver
         $ ssm-manage shell
     """
+    docopt(main.__doc__, options_first=True)
     return subprocess.call(["ssm", "python", "manage.py"] + sys.argv[1:])
 
 

--- a/shadowsocks_manager/utils/tests.py
+++ b/shadowsocks_manager/utils/tests.py
@@ -130,13 +130,13 @@ class ManagementCommandsTestCase(TestCase):
         self.assertIn('Successfully created superuser', output.strip('\n'))
 
 class ScriptTestCase(TestCase):
+    # Get the coverage file name from the environment variable, set by tox
+    coverage_file = os.environ.get('COVERAGE_FILE')
+    os.environ['COVERAGE_FILE'] = '{}.utils.script'.format(coverage_file)
+
     def setUp(self):
         # Set default runner
         self.script_runner = ['python']
-
-        # Get the coverage file name from the environment variable, set by tox
-        self.coverage_file = os.environ.get('COVERAGE_FILE')
-        os.environ['COVERAGE_FILE'] = '{}.utils.script'.format(self.coverage_file)
 
         if self.coverage_file:
             self.script_runner = ['coverage', 'run']

--- a/shadowsocks_manager/utils/tests.py
+++ b/shadowsocks_manager/utils/tests.py
@@ -11,9 +11,14 @@ import subprocess
 from django.test import TestCase
 from django.core.management import call_command
 from django.contrib.auth.models import User
+import tempfile
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from utils.viewsets import CompatModelViewSet
-
+from utils.version import __version__, __build__, set_buildno, get_buildno, get_version
 
 import logging
 # Get a logger for this django app
@@ -36,6 +41,74 @@ class CompatModelViewSetTestCase(TestCase):
 
         obj = Py3ViewSet()
         self.assertTrue(any(getattr(obj, attr, None) == ['foo'] for attr in ['filter_fields', 'filterset_fields']))
+
+
+class VersionTestCase(TestCase):
+    def test_version_set_buildno(self):
+        with tempfile.NamedTemporaryFile(mode='w+', delete=True) as f:
+            initial_content = '__build__ = ""\n'
+            f.write(initial_content)
+            f.flush() 
+
+            set_buildno('abcdef0', f.name)
+
+            f.seek(0)
+            self.assertIn('abcdef0', f.read())
+
+    def test_version_get_buildno(self):
+        self.assertTrue(get_buildno())
+
+    @patch('subprocess.check_output')
+    def test_version_get_buildno_missing_git_dir(self, mock_check_output):
+        def custom_check_output_side_effect(*args, **kwargs):
+            if args[0] == ['/usr/bin/git', 'rev-parse', '--is-inside-work-tree']:
+                return b''
+
+        mock_check_output.side_effect = custom_check_output_side_effect
+        result = get_buildno()
+        self.assertEqual(result, '')
+
+    @patch('subprocess.check_output')
+    def test_version_get_buildno_clean(self, mock_check_output):
+        def custom_check_output_side_effect(*args, **kwargs):
+            if args[0] == ['/usr/bin/git', 'rev-parse', '--is-inside-work-tree']:
+                return b'true\n'
+            elif args[0] == ['/usr/bin/git', 'rev-parse', '--short', 'HEAD']:
+                return b'abcdef0\n'
+            elif args[0] == ['/usr/bin/git', 'status', '--porcelain']:
+                return b''
+
+        mock_check_output.side_effect = custom_check_output_side_effect
+        self.assertRegex(get_buildno(), r'^[a-f0-9]+$')
+
+    @patch('subprocess.check_output')
+    def test_version_get_buildno_dirty(self, mock_check_output):
+        def custom_check_output_side_effect(*args, **kwargs):
+            if args[0] == ['/usr/bin/git', 'rev-parse', '--is-inside-work-tree']:
+                return b'true\n'
+            elif args[0] == ['/usr/bin/git', 'rev-parse', '--short', 'HEAD']:
+                return b'abcdef0\n'
+            elif args[0] == ['/usr/bin/git', 'status', '--porcelain']:
+                return b'M dirty_file\n'
+
+        mock_check_output.side_effect = custom_check_output_side_effect
+        self.assertRegex(get_buildno(), r'^[a-f0-9]+-\d{8}-\d{4}$')
+
+    def test_version_get_version(self):
+        self.assertEqual(get_version(), 'v{}'.format(__version__))
+
+    def test_version_get_version_full(self):
+        self.assertEqual(get_version(full=True), 'v{}-{}'.format(__version__, __build__ or get_buildno()))
+
+    custom_build = 'abcdef0-20201231-2359'
+    @patch('utils.version.__build__', custom_build)
+    def test_version_get_version_full_with_custom_build(self):
+        self.assertEqual(get_version(full=True), 'v{}-{}'.format(__version__, self.custom_build))
+
+    @patch('utils.version.get_buildno')
+    def test_version_get_version_full_with_no_build(self, mock_get_buildno):
+        mock_get_buildno.return_value = ''
+        self.assertEqual(get_version(full=True), 'v{}'.format(__version__))
 
 
 class ManagementCommandsTestCase(TestCase):
@@ -83,6 +156,7 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/__main__.py', 'ls', '-1', '__main__.py'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertEqual(output.strip('\n'), '__main__.py')
 
@@ -90,6 +164,7 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(['ssm', 'ls', '-1', '__main__.py'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertEqual(output.strip('\n'), '__main__.py')
 
@@ -97,6 +172,7 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/manage.py', 'check'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertIn('no issues', output.strip('\n'))
 
@@ -104,6 +180,7 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(['ssm-manage', 'check'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertIn('no issues', output.strip('\n'))
 
@@ -111,22 +188,26 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/dotenv.py', '-w', 'TEST=1'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
 
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/dotenv.py'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertIn('TEST=1', output.strip('\n'))
 
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/dotenv.py', '-w', 'TEST=2'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
 
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/dotenv.py'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertIn('TEST=2', output.strip('\n'))
 
@@ -134,12 +215,14 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(['ssm-dotenv', '-w', 'TEST=1'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
 
     def test_script_celery(self):
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/celery_app.py', '--version'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertRegex(output.strip('\n'), r'\d+\.\d+\.\d+')
 
@@ -147,6 +230,7 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(['ssm-celery', '--version'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertRegex(output.strip('\n'), r'\d+\.\d+\.\d+')
 
@@ -154,6 +238,7 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/uwsgi.py', '--version'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        #self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertRegex(output.strip('\n'), r'\d+\.\d+\.\d+')
 
@@ -161,6 +246,54 @@ class ScriptTestCase(TestCase):
         result = subprocess.Popen(['ssm-uwsgi', '--version'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, error = result.communicate()
+        #self.assertFalse(error)
         self.assertEqual(result.returncode, 0)
         self.assertRegex(output.strip('\n'), r'\d+\.\d+\.\d+')
-        
+
+    def test_script_version(self):
+        result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/version.py'],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        output, error = result.communicate()
+        self.assertFalse(error)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(output.strip('\n'), 'v{}'.format(__version__))
+
+    def test_script_version_full(self):
+        result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/version.py', '--full'],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        output, error = result.communicate()
+        self.assertFalse(error)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(output.strip('\n'), 'v{}-{}'.format(__version__, __build__ or get_buildno()))
+
+    def test_script_version_get_build(self):
+        result = subprocess.Popen(self.script_runner + ['shadowsocks_manager/utils/version.py', '--get-build'],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        output, error = result.communicate()
+        self.assertFalse(error)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(output.strip('\n'), get_buildno())
+
+    def test_cli_version(self):
+        result = subprocess.Popen(['ssm-version'],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        output, error = result.communicate()
+        self.assertFalse(error)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(output.strip('\n'), 'v{}'.format(__version__))
+
+    def test_cli_version_full(self):
+        result = subprocess.Popen(['ssm-version', '--full'],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        output, error = result.communicate()
+        self.assertFalse(error)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(output.strip('\n'), 'v{}-{}'.format(__version__, __build__ or get_buildno()))
+
+    def test_cli_version_get_build(self):
+        result = subprocess.Popen(['ssm-version', '--get-build'],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        output, error = result.communicate()
+        self.assertFalse(error)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(output.strip('\n'), get_buildno())

--- a/shadowsocks_manager/utils/version.py
+++ b/shadowsocks_manager/utils/version.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+"""
+Description:
+    ssm-version is a command-line utility for administrative tasks.
+    It's used to show the version and to maintain the build number of the shadowsocks-manager.
+
+Usage:
+    ssm-version
+    ssm-version [--full]
+    ssm-version [--get-build]
+    ssm-version [--set-build]
+
+Options:
+    --full          Show the full version of the package.
+    --get-build     Get the build number of the package.
+    --set-build     Set the build number of the package.
+
+Returns:
+    None
+
+Example:
+    $ ssm-version
+"""
+import os
+import sys
+import signal
+from datetime import datetime
+import subprocess
+from docopt import docopt
+
+try:
+    from shadowsocks_manager import __version__, __build__
+except ImportError:
+    from shadowsocks_manager.shadowsocks_manager import __version__, __build__
+
+
+def signal_handler(sig, frame):
+    print('{} [{}]: Interrupt received'.format('ssm-vesion', os.getpid()))
+    sys.exit(255)
+
+signal.signal(signal.SIGINT, signal_handler)
+
+
+def set_buildno(build, version_file):
+    """
+    Set the build number in the version file.
+    An existing line starting with '__build__ =' will be replaced with the new build number.
+    A new line will be added if the line does not exist.
+    If the build number is None or empty, it's set as a empty string.
+    """
+    if build is None:
+        build = ''
+
+    found = False
+    with open(version_file, 'r') as f:
+        lines = f.readlines()
+
+    new_line = '__build__ = "{}"\n'.format(build)
+    with open(version_file, 'w') as f:
+        for line in lines:
+            if line.startswith('__build__ ='):
+                f.write(new_line)
+                found = True
+                print("{}: {}".format(version_file, build))
+            else:
+                f.write(line)
+    return found
+
+
+def get_buildno():
+    """
+    Get the build number by checking the git repository.
+
+    Build number format: {short_hash}[-{timestamp}]
+        - short_hash:   the short hash of the commit
+        - timestamp:    the timestamp of the build, which is appended if the working directory is dirty
+    """
+    try:
+        # Check if inside a git work tree
+        with open(os.devnull, 'w') as devnull:
+            is_git_repo = subprocess.check_output(['/usr/bin/git', 'rev-parse', '--is-inside-work-tree'], stderr=devnull).strip().decode('utf-8')
+        if is_git_repo != 'true':
+            return ''
+
+        # get the build information from git commit
+        build = subprocess.check_output(['/usr/bin/git', 'rev-parse', '--short', 'HEAD']).strip().decode('utf-8')
+
+        # if the working directory is dirty, append timestamp to the build information
+        if subprocess.check_output(['/usr/bin/git', 'status', '--porcelain']).strip().decode('utf-8'):
+            ts = None
+            try:
+                from datetime import timezone
+                ts = datetime.now(timezone.utc).strftime('%Y%m%d-%H%M')
+            except ImportError:
+                ts = datetime.utcnow().strftime('%Y%m%d-%H%M')
+            return '{}-{}'.format(build, ts)
+        else:
+            return '{}'.format(build)
+    except Exception:
+        return ''
+
+
+def get_version(full=False):
+    """
+    Get the version of the package.
+
+    Version format: v{version}
+    Full version format: v{version}[-{build}]
+
+        - version: the package version
+            - The {package}.__version__ is always hornored.
+            - The package building process should be responsible for updating the {package}.__version__.
+            - For dev environment, merging the master branch back should update the {package}.__version__.
+
+        - build: the package build number
+            - First try to get the build number from the {package}.__build__ (for package distribution).
+            - If failed fall back to use the git repository (for dev environment).
+            - The package building process should be responsible for updating the {package}.__build__.
+    """
+    version = 'v{}'.format(__version__ or '0.0.0')
+
+    if full:
+        build = __build__ or get_buildno()
+        if build:
+            version = '{}-{}'.format(version, build)
+
+    return version
+
+
+def get_version_file():
+    django_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(django_root, 'shadowsocks_manager/__init__.py')
+
+
+def main():
+    arguments = docopt(__doc__)
+
+    if not any(arguments.values()):
+        print(get_version())
+    elif arguments['--full']:
+        print(get_version(full=True))
+    elif arguments['--get-build']:
+        print(get_buildno())
+    elif arguments['--set-build']:
+        build = get_buildno()
+        version_file = get_version_file()
+        set_buildno(build, version_file)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
- Fix env name in settings.py: SSM_CACHES_BACKEND
- Fix run_cmd_opts: docker-build-and-run.sh
- Fix arguments order: ssm-dev-start
- Fix coverage data filename: utils/tests
- Update ci-unittest.yml: Ignore any tag push
- Update README.md: Add codefactor.io badge
- Update utils/tests: test cases for version.py
- Improve security: rendering version in site header
- Improve: use docopt to render help
- Improve: use UTC timestamp as tag in docker-build-and-run.sh
- Improve: write a build number to docker image distribution
- Refactor: move version logic from settings to utils/version.py
- Refactor: Remove unused files
