### PR TITLE
ci-docker: publish slim as latest tag (alpine python3.12 broken)

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -45,8 +45,8 @@ jobs:
           tags: |
             ${{ vars.DOCKERHUB_USERNAME }}/shadowsocks-manager:${{ matrix.dist }}-latest
             ${{ vars.DOCKERHUB_USERNAME }}/shadowsocks-manager:${{ matrix.dist }}-${{ env.VERSION }}
-            ${{ matrix.dist == 'alpine' && format('{0}/shadowsocks-manager:latest', vars.DOCKERHUB_USERNAME) || null }}
-            ${{ matrix.dist == 'alpine' && format('{0}/shadowsocks-manager:{1}', vars.DOCKERHUB_USERNAME, env.VERSION) || null }}
+            ${{ matrix.dist == 'slim' && format('{0}/shadowsocks-manager:latest', vars.DOCKERHUB_USERNAME) || null }}
+            ${{ matrix.dist == 'slim' && format('{0}/shadowsocks-manager:{1}', vars.DOCKERHUB_USERNAME, env.VERSION) || null }}
           platforms: linux/amd64,linux/arm64
 
   tag-commit:


### PR DESCRIPTION
## Summary

- The published `:latest` tag is currently sourced from the alpine variant. The alpine 3.20 apk python3.12.4 build has a corrupt `_datetime` C extension that breaks `datetime.strftime`, which cascades through `xmlrpc.client` to crash `supervisord` at container startup. Affects both amd64 and arm64.
- Switch `:latest` and `:{VERSION}` to publish from the slim variant (Debian Bookworm + python:3.12-slim), which is unaffected. The matrix continues to push `-alpine`, `-debian`, `-slim` flavored tags as before.

## Reproduce

\`\`\`bash
docker pull --platform linux/amd64 alexzhangs/shadowsocks-manager:latest
docker run --rm --entrypoint /bin/bash alexzhangs/shadowsocks-manager:latest -c \\
    'python3 -c "from datetime import datetime; print(datetime(1,1,1).strftime(\"%Y\"))"'
# AttributeError: 'datetime.datetime' object has no attribute 'times'

docker pull --platform linux/amd64 alexzhangs/shadowsocks-manager:slim-latest
docker run --rm --entrypoint /bin/bash alexzhangs/shadowsocks-manager:slim-latest -c \\
    'python3 -c "from datetime import datetime; print(datetime(1,1,1).strftime(\"%Y\"))"'
# 1   (works)
\`\`\`

## Impact discovered through

`aws-cfn-vpn` 2026 cluster deploy: EC2 userdata runs `install.sh` which pulls `:latest`, container exits with code 1 inside ~20s. Workaround applied at the deploy layer is `SSMVersion=slim-latest`; this PR removes the need for that workaround for downstream deployers.

## Optional follow-up (not in this PR)

Add a post-`install.sh` health check to the `docker-run` job to catch future container-startup regressions before they ship as `:latest`.

## Test plan

- [ ] Manual \`workflow_dispatch\` of \`ci-docker\`, confirm \`:latest\` and \`:{VERSION}\` Docker Hub tags are now slim-based
- [ ] Confirm \`-alpine\`, \`-debian\`, \`-slim\` tags continue to be published unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)