### PR TITLE
ci-docker: restore alpine as latest + add container health gate

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -45,8 +45,8 @@ jobs:
           tags: |
             ${{ vars.DOCKERHUB_USERNAME }}/shadowsocks-manager:${{ matrix.dist }}-latest
             ${{ vars.DOCKERHUB_USERNAME }}/shadowsocks-manager:${{ matrix.dist }}-${{ env.VERSION }}
-            ${{ matrix.dist == 'slim' && format('{0}/shadowsocks-manager:latest', vars.DOCKERHUB_USERNAME) || null }}
-            ${{ matrix.dist == 'slim' && format('{0}/shadowsocks-manager:{1}', vars.DOCKERHUB_USERNAME, env.VERSION) || null }}
+            ${{ matrix.dist == 'alpine' && format('{0}/shadowsocks-manager:latest', vars.DOCKERHUB_USERNAME) || null }}
+            ${{ matrix.dist == 'alpine' && format('{0}/shadowsocks-manager:{1}', vars.DOCKERHUB_USERNAME, env.VERSION) || null }}
           platforms: linux/amd64,linux/arm64
 
   tag-commit:
@@ -82,3 +82,11 @@ jobs:
           retry_on: error
           command: |
             bash install.sh
+      - name: Verify container healthy
+        run: |
+          sleep 20
+          state=$(docker inspect -f '{{.State.Status}}' ssm-${{ env.SSM_VERSION }})
+          if [[ "$state" != "running" ]]; then
+            docker logs ssm-${{ env.SSM_VERSION }} | tail -50
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- The alpine `_datetime` bug that prompted [#38](https://github.com/alexzhangs/shadowsocks-manager/pull/38) (commit `9afeb4c`) is fixed upstream on the current `python:3.12-alpine` base. Verified locally — `datetime.strftime`, `xmlrpc.client` import, and `supervisord --version` all succeed inside a freshly built `docker/alpine` image, and the full entrypoint runs cleanly (supervisord stays up; Django migrations + superuser creation complete).
- Restore alpine as the publisher for the unversioned `latest` and bare-`${VERSION}` Docker Hub tags (revert of the `9afeb4c` gate flip).
- Add a `docker-run` post-install health check that inspects `ssm-${SSM_VERSION}` 20s after `install.sh` and dumps logs on non-running state — would have caught the original alpine crash at publish time.

## Test plan

- [x] Build `docker/alpine/Dockerfile` locally on Python 3.12-alpine (Alpine 3.21+).
- [x] `python3 -c "from datetime import datetime; print(datetime(1,1,1).strftime('%Y'))"` → `0001`.
- [x] `python3 -c "import xmlrpc.client"` → no error.
- [x] `supervisord --version` → `4.2.5`.
- [x] Full entrypoint: container stays in `running` state; supervisord + nginx start; Django migrations complete.
- [ ] Run `workflow_dispatch` on `ci-docker` to confirm: (a) `latest` is published from alpine, (b) new `Verify container healthy` step fires.