### PR TITLE
Add Python 3.14 support across Docker, CI, tox, and packaging

### DIFF
--- a/.github/workflows/ci-pypi.yml
+++ b/.github/workflows/ci-pypi.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12.3']
+        python-version: ['3.14.5']
     outputs:
       NEW_VERSION: ${{ steps.bump-version.outputs.NEW_VERSION }}
     steps:
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12.3']
+        python-version: ['3.14.5']
     env:
       NEW_VERSION: ${{ needs.pypi-py3-build-and-upload.outputs.NEW_VERSION }}
     steps:

--- a/.github/workflows/ci-testpypi.yml
+++ b/.github/workflows/ci-testpypi.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12.3']
+        python-version: ['3.14.5']
     outputs:
       NEW_VERSION: ${{ steps.bump-version.outputs.NEW_VERSION }}
     steps:
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12.3']
+        python-version: ['3.14.5']
     env:
       NEW_VERSION: ${{ needs.testpypi-py3-build-and-upload.outputs.NEW_VERSION }}
     steps:

--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Install system packages
         run: |
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python for tox
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install tox
         run: |
           pip install --upgrade pip
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Python for tox
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install tox
         run: |
           pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ The development of this project requires Python 3.x.
 1. Bootstrap the tox environment
 
     ```sh
-    pyenv install 3.12
-    pyenv virtualenv 3.12 tox
+    pyenv install 3.14
+    pyenv virtualenv 3.14 tox
     pyenv activate tox
     pip install -r tox.txt
     export VIRTUALENV_DISCOVERY=pyenv
@@ -287,7 +287,7 @@ The development of this project requires Python 3.x.
 1. Install the Python versions that the project should test against
 
     ```sh
-    pyenv install 3.8 3.9 3.10 3.11
+    pyenv install 3.8 3.9 3.10 3.11 3.12 3.13 3.14
     ```
 
 1. Clone the project code
@@ -306,7 +306,7 @@ The development of this project requires Python 3.x.
 1. Run the unit tests against all the supported Python versions
 
     ```sh
-    tox run -qe py38,py39,py310,py311,py312,py313
+    tox run -qe py38,py39,py310,py311,py312,py313,py314
     ```
 
 1. Combine the coverage data and generate the report
@@ -345,7 +345,7 @@ The development of this project requires Python 3.x.
     tox run -qe act-ci-unittest
 
     # multiple Python versions
-    tox run -qe act-ci-unittest -- --matrix python-version:3.11 --matrix python-version:3.12
+    tox run -qe act-ci-unittest -- --matrix python-version:3.13 --matrix python-version:3.14
     ```
 
 1. Build the Docker images and run the containers

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -30,7 +30,7 @@
 # For more information, please refer to the project repository:
 #   https://github.com/alexzhangs/shadowsocks-manager
 #
-FROM python:3.12-alpine
+FROM python:3.14-alpine
 
 ENV DIST alpine
 

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -30,7 +30,7 @@
 # For more information, please refer to the project repository:
 #   https://github.com/alexzhangs/shadowsocks-manager
 #
-FROM python:3.12
+FROM python:3.14
 
 ENV DIST=debian
 

--- a/docker/slim/Dockerfile
+++ b/docker/slim/Dockerfile
@@ -30,7 +30,7 @@
 # For more information, please refer to the project repository:
 #   https://github.com/alexzhangs/shadowsocks-manager
 #
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 ENV DIST slim
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: Proxy Servers",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# The following environment variables are optional for runing the testenv:py{38,39,310,311,312,313}:
+# The following environment variables are optional for runing the testenv:py{38,39,310,311,312,313,314}:
 #   SSM_TEST_CACHES_BACKEND
 #   SSM_TEST_MEMCACHED_PORT
 #   SSM_TEST_RABBITMQ_PORT
@@ -37,7 +37,7 @@
 
 [tox]
 envlist =
-    py{38,39,310,311,312,313},
+    py{38,39,310,311,312,313,314},
     cov,codecov,pypi,act-ci-unittest,bar,dev
 
 [testenv]
@@ -78,7 +78,7 @@ commands =
 commands_post =
     - {env:DOCKER_CLEANUP_CMD}
 
-[testenv:py{38,39,310,311,312,313}]
+[testenv:py{38,39,310,311,312,313,314}]
 description = Run the test with Django test and coverage under {envname}
 pass_env =
     SSM_TEST_CACHES_BACKEND


### PR DESCRIPTION
## Summary

- Adds Python 3.14 support across the Dockerfiles (`alpine`, `slim`, `debian`), CI matrix, tox envlist, pyproject classifiers, and the pinned `python-version` in `ci-pypi.yml`/`ci-testpypi.yml` (`3.12.3` → `3.14.5`).
- Existing 3.8–3.13 matrix entries are kept; 3.8 and 3.9 are upstream-EOL but left in by request.
- Existing dep guard `legacy-cgi; python_version >= '3.13'` already covers 3.14 — no new stdlib removals affect this project.
- Smoke-tested all three images locally on arm64: image-python imports of `xmlrpc.client`, `datetime`, and `shadowsocks_manager` succeed; `supervisord` binary runs and its module imports under the system python.
- README §8 (Development) updated to match: bumps the tox bootstrap python from 3.12 → 3.14, completes the per-target `pyenv install` list (which was previously stuck at 3.8–3.11 even though tox had moved on to 3.13), bumps `tox -qe py38..py313` → `..py314`, and bumps the act-ci-unittest matrix example to 3.13/3.14.
- No published-version bump — `0.1.18` is unchanged.

CI on develop passed all 7 matrix entries + codecov on run [26087525538](https://github.com/alexzhangs/shadowsocks-manager/actions/runs/26087525538).

## Test plan

- [x] `ci-unittest` matrix green for 3.8 / 3.9 / 3.10 / 3.11 / 3.12 / 3.13 / 3.14 on develop
- [x] `codecov` job green on develop
- [x] `docker build` succeeds locally for alpine / slim / debian (`python:3.14-{alpine,slim,}`)
- [x] In-container smoke: `import xmlrpc.client`, `import datetime`, `import shadowsocks_manager`; `supervisord --version` and `python3 -c 'import supervisor'` (system python) all OK
- [x] `pyenv install 3.14.5` + `tox -e py314 --notest` resolve to /Users/alex/.pyenv/versions/3.14.5 via `virtualenv-pyenv` (verified after `brew upgrade pyenv` 2.5.5 → 2.6.31, since older pyenv didn't index 3.14)
- [ ] Re-run `ci-unittest` and `ci-testpypi` on this PR
