### PR TITLE
fix: pin rabbitmq to 3.13 + supervisord logs to container stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,20 +422,43 @@ The CI/CD workflows are defined in the `.github/workflows` directory.
     docker logs <container_id>
     ```
 
-1. Check the logs (inside container)
+1. Check the logs
+
+    Per-program output from uwsgi, celery worker, and celery beat is routed
+    to the container's stdout (`stdout_logfile=/dev/fd/1` in the supervisord
+    confs). Read them from the host via `docker logs`:
 
     ```
-    # supervisor (debian)
-    cat /var/log/supervisor/supervisord.log 
+    # all programs interleaved, last 200 lines
+    docker logs --tail 200 ssm-${SSM_VERSION}
+
+    # follow live
+    docker logs --follow ssm-${SSM_VERSION}
+
+    # only last 5 minutes
+    docker logs --since 5m ssm-${SSM_VERSION}
+
+    # filter by program prefix (supervisord emits lines like
+    # "ssm-celery-worker: ..." for each program)
+    docker logs ssm-${SSM_VERSION} 2>&1 | grep '^ssm-celery-worker'
+    ```
+
+    Supervisord's own log still lives inside the container:
+
+    ```
+    # supervisor (debian / slim)
+    docker exec ssm-${SSM_VERSION} cat /var/log/supervisor/supervisord.log
 
     # supervisor (alpine)
-    cat /var/log/supervisord.log
+    docker exec ssm-${SSM_VERSION} cat /var/log/supervisord.log
+    ```
 
-    # uWSGI
-    cat /var/log/ssm-uwsgi.log
+    Note: docker's log driver controls retention. By default it's
+    unbounded — set the daemon-level rotation policy in
+    `/etc/docker/daemon.json` to cap it, e.g.:
 
-    # Celery
-    cat /var/log/ssm-cerlery*
+    ```json
+    {"log-driver":"json-file","log-opts":{"max-size":"50m","max-file":"3"}}
     ```
 
 1. Check the services (inside container)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ docker network create ssm-network
 docker run -d --network ssm-network --name ssm-memcached memcached
 
 # run rabbitmq, used by celery
-docker run -d --network ssm-network --name ssm-rabbitmq rabbitmq
+# pin to 3.13 — rabbitmq 4.x rejects the deprecated `transient_nonexcl_queues`
+# AMQP feature that Celery 5.x still uses
+docker run -d --network ssm-network --name ssm-rabbitmq rabbitmq:3.13
 
 # create a directory to store the data, it will be mounted to the shadowsocks-manager container
 mkdir -p ~/ssm-volume

--- a/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
+++ b/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
@@ -4,7 +4,12 @@ command=ssm-celery worker -l info
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true
-stdout_logfile=/var/log/ssm-celery-worker.log
+; Send logs to container stdout (fd 1) so the docker host log driver applies its
+; rotation policy. Writing to a file inside the container makes rotated files
+; accumulate in the overlay2 writable layer, which is NOT reclaimed when the
+; in-container logrotate unlinks them — disk grows unboundedly.
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 killasgroup=true
 
 [program:ssm-celery-beat]
@@ -13,5 +18,6 @@ command=ssm-celery beat -l info
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true
-stdout_logfile=/var/log/ssm-celery-beat.log
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 killasgroup=true

--- a/deploy/supervisor/vendors/shadowsocks-manager-uwsgi.conf
+++ b/deploy/supervisor/vendors/shadowsocks-manager-uwsgi.conf
@@ -4,6 +4,8 @@ command=ssm-uwsgi
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true
-stdout_logfile=/var/log/ssm-uwsgi.log
+; See shadowsocks-manager-celery.conf for the rationale of /dev/fd/1.
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 killasgroup=true
 stopsignal=HUP

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ function main () {
 
     echo "Running $rabbitmq_container_name ..."
     # run rabbitmq, used by celery
-    docker run --restart=always -d --network "$ssm_network_name" --name "$rabbitmq_container_name" rabbitmq
+    docker run --restart=always -d --network "$ssm_network_name" --name "$rabbitmq_container_name" rabbitmq:3.13
 
     # run shadowsocks-manager
     echo "Running $ssm_container_name ..."


### PR DESCRIPTION
## Summary

Two related fixes for celery worker reliability + log-volume issues observed on a freshly-deployed shadowsocks-manager hub. Symptoms: celery worker log file grows ~90 MB/hour and fills the host disk within ~2 days; scheduled celery beat tasks (e.g. nightly IP rotation in our setup) never execute even though beat dispatches them.

### 1. `install.sh`: pin `rabbitmq` to `rabbitmq:3.13`

`docker run ... rabbitmq` resolves to `rabbitmq:latest` = 4.3.0, which rejects the deprecated `transient_nonexcl_queues` AMQP 0.9.1 feature by default. Celery 5.x still uses transient non-exclusive queues for its event/result channels, so every `queue.declare` raises:

```
amqp.exceptions.InternalError: Queue.declare: (541) INTERNAL_ERROR
- Feature transient_nonexcl_queues is deprecated.
```

The celery worker's consumer restarts 5×/second, hits `RestartFreqExceeded`, and emits a full CRITICAL stack trace on every cycle. RabbitMQ 3.13 (last 3.x LTS) is well-tested with Celery 5.4 and still permits the deprecated feature. Long-term Celery should switch to durable queues, but pinning fixes the immediate breakage.

### 2. `deploy/supervisor/vendors/*.conf`: route logs to `/dev/fd/1`

`stdout_logfile=/var/log/ssm-celery-worker.log` writes inside the container's overlay2 writable layer. Even with python logging's RotatingFileHandler doing in-process rotation, the **overlay2 driver does not reclaim space when rotated files are unlinked** — the diff layer keeps growing. Net result: in-container "rotation" provides zero disk relief.

Routing to `/dev/fd/1` (`stdout_logfile_maxbytes=0` disables supervisord's own size-based rotation, which doesn't make sense for an FD) lets the docker host-side log driver (configurable via `/etc/docker/daemon.json` `log-opts.max-size` / `max-file`) handle rotation properly. The bytes live outside the container's writable layer where they can be reclaimed.

Applied to both `shadowsocks-manager-celery.conf` and `shadowsocks-manager-uwsgi.conf` for consistency.

## Verified

End-to-end on a live cluster: after swapping `rabbitmq` → `rabbitmq:3.13` and restarting the ssm container, celery worker log volume dropped from ~90 MB/hour to near-zero. Scheduled celery beat tasks now run reliably.

## Test plan

- [ ] `bash install.sh` builds + boots the stack with rabbitmq:3.13. Verify `docker exec ssm-<version> tail /var/log/...` paths no longer exist (now go to stdout). Verify `docker logs ssm-<version>` shows the combined supervisord output.
- [ ] Confirm a celery task can be dispatched (`ssm-manage shell` → `from statistic.tasks import statistic; statistic.delay()`) and runs without `RestartFreqExceeded` in the log.

## Optional follow-up (out of scope for this PR)

- Drop the deprecated AMQP feature in celery config by setting `task_default_queue_durable=True` etc. Would let us track rabbitmq's actual `latest` going forward. Bigger change; can be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
