### PR TITLE
Release develop → master: rabbitmq pin + supervisord stdout logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,20 +422,43 @@ The CI/CD workflows are defined in the `.github/workflows` directory.
     docker logs <container_id>
     ```
 
-1. Check the logs (inside container)
+1. Check the logs
+
+    Per-program output from uwsgi, celery worker, and celery beat is routed
+    to the container's stdout (`stdout_logfile=/dev/fd/1` in the supervisord
+    confs). Read them from the host via `docker logs`:
 
     ```
-    # supervisor (debian)
-    cat /var/log/supervisor/supervisord.log 
+    # all programs interleaved, last 200 lines
+    docker logs --tail 200 ssm-${SSM_VERSION}
+
+    # follow live
+    docker logs --follow ssm-${SSM_VERSION}
+
+    # only last 5 minutes
+    docker logs --since 5m ssm-${SSM_VERSION}
+
+    # filter by program prefix (supervisord emits lines like
+    # "ssm-celery-worker: ..." for each program)
+    docker logs ssm-${SSM_VERSION} 2>&1 | grep '^ssm-celery-worker'
+    ```
+
+    Supervisord's own log still lives inside the container:
+
+    ```
+    # supervisor (debian / slim)
+    docker exec ssm-${SSM_VERSION} cat /var/log/supervisor/supervisord.log
 
     # supervisor (alpine)
-    cat /var/log/supervisord.log
+    docker exec ssm-${SSM_VERSION} cat /var/log/supervisord.log
+    ```
 
-    # uWSGI
-    cat /var/log/ssm-uwsgi.log
+    Note: docker's log driver controls retention. By default it's
+    unbounded — set the daemon-level rotation policy in
+    `/etc/docker/daemon.json` to cap it, e.g.:
 
-    # Celery
-    cat /var/log/ssm-cerlery*
+    ```json
+    {"log-driver":"json-file","log-opts":{"max-size":"50m","max-file":"3"}}
     ```
 
 1. Check the services (inside container)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ docker network create ssm-network
 docker run -d --network ssm-network --name ssm-memcached memcached
 
 # run rabbitmq, used by celery
-docker run -d --network ssm-network --name ssm-rabbitmq rabbitmq
+# pin to 3.13 — rabbitmq 4.x rejects the deprecated `transient_nonexcl_queues`
+# AMQP feature that Celery 5.x still uses
+docker run -d --network ssm-network --name ssm-rabbitmq rabbitmq:3.13
 
 # create a directory to store the data, it will be mounted to the shadowsocks-manager container
 mkdir -p ~/ssm-volume

--- a/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
+++ b/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
@@ -4,7 +4,12 @@ command=ssm-celery worker -l info
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true
-stdout_logfile=/var/log/ssm-celery-worker.log
+; Send logs to container stdout (fd 1) so the docker host log driver applies its
+; rotation policy. Writing to a file inside the container makes rotated files
+; accumulate in the overlay2 writable layer, which is NOT reclaimed when the
+; in-container logrotate unlinks them — disk grows unboundedly.
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 killasgroup=true
 
 [program:ssm-celery-beat]
@@ -13,5 +18,6 @@ command=ssm-celery beat -l info
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true
-stdout_logfile=/var/log/ssm-celery-beat.log
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 killasgroup=true

--- a/deploy/supervisor/vendors/shadowsocks-manager-uwsgi.conf
+++ b/deploy/supervisor/vendors/shadowsocks-manager-uwsgi.conf
@@ -4,6 +4,8 @@ command=ssm-uwsgi
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true
-stdout_logfile=/var/log/ssm-uwsgi.log
+; See shadowsocks-manager-celery.conf for the rationale of /dev/fd/1.
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 killasgroup=true
 stopsignal=HUP

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ function main () {
 
     echo "Running $rabbitmq_container_name ..."
     # run rabbitmq, used by celery
-    docker run --restart=always -d --network "$ssm_network_name" --name "$rabbitmq_container_name" rabbitmq
+    docker run --restart=always -d --network "$ssm_network_name" --name "$rabbitmq_container_name" rabbitmq:3.13
 
     # run shadowsocks-manager
     echo "Running $ssm_container_name ..."


### PR DESCRIPTION
Promotes the merged hub-stability fixes from develop to master, triggering a new shadowsocks-manager release.

    Includes PR #41:
    - install.sh: pin rabbitmq to 3.13 (works around RabbitMQ 4.x deprecation that crashes celery worker)
    - supervisord celery+uwsgi confs: route logs to container stdout (avoids overlay2 disk bloat)
    - README troubleshooting + manual-install sections updated

    Verified end-to-end on the live AIVIEW VPN cluster: celery worker log volume dropped from ~90 MB/hour to ~19 KB/hour after the rabbitmq pin landed.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)