### PR TITLE
fix(node): refresh _original_* snapshot after save() — cascades on toggle-twice

### DIFF
--- a/shadowsocks_manager/shadowsocks/models.py
+++ b/shadowsocks_manager/shadowsocks/models.py
@@ -223,8 +223,29 @@ class Node(StatisticMethod):
 
     def __init__(self, *args, **kwargs):
         super(Node, self).__init__(*args, **kwargs)
+        self._snapshot_original()
+
+    def _snapshot_original(self):
+        """
+        Capture the current field values as the "original" reference state
+        so subsequent save()s can detect what changed.
+
+        Called at __init__ time (so freshly-loaded instances reflect DB state)
+        AND after every save() (so a second save() on the SAME in-memory
+        instance correctly compares against the just-written values, not
+        the original-construction values).
+
+        Without the post-save snapshot, the toggle-twice pattern in
+        Node.change_ips_softly() silently fails to cascade the second toggle
+        to NodeAccount.is_active — see the AIVIEW deployment's
+        NOTES/vpn-rotation-night-1-postmortem.md for the full trace.
+        """
         self._original_is_active = self.is_active
         self._original_public_ip = self.public_ip
+
+    def save(self, *args, **kwargs):
+        super(Node, self).save(*args, **kwargs)
+        self._snapshot_original()
 
     def __str__(self):
         return self.name

--- a/shadowsocks_manager/shadowsocks/tests.py
+++ b/shadowsocks_manager/shadowsocks/tests.py
@@ -678,3 +678,125 @@ class ManagementCommandTestCase(AppTestCase):
     def test_cmd_shadowsocks_config_cache_timeout(self):
         call_command('shadowsocks_config', '--cache-timeout', '99')
         self.assertEqual(models.Config.load().cache_timeout, 99)
+
+
+class NodeOriginalSnapshotTestCase(BaseTestCase):
+    """
+    Regression tests for the `_original_*` field-snapshot tracking on the
+    Node model.
+
+    Background: Node.__init__ captures `_original_is_active` and
+    `_original_public_ip` so that `Node.on_update()` can detect "activity
+    changed" and cascade is_active to all NodeAccount rows. Prior to the
+    `save()` override + `_snapshot_original()` helper, the snapshot was
+    only refreshed at __init__ — so a second `save()` on the SAME
+    in-memory instance compared the new value against the *construction-
+    time* original, not the *just-written* DB value. That broke the
+    cascade in `Node.change_ips_softly()` step-5 reactivation when the
+    AWS Config event arrived after the 60s sleep instead of during it,
+    leaving NodeAccount rows permanently inactive after a rotation.
+    """
+
+    def _make_account(self, username='9001'):
+        return models.Account.objects.create(
+            username=username,
+            password='unit-test-pw',
+            is_active=True,
+        )
+
+    def _make_node(self, name='unit-test-node'):
+        # Use a public_ip that won't accidentally hit a real service.
+        return models.Node.objects.create(
+            name=name,
+            public_ip='192.0.2.1',  # TEST-NET-1, RFC 5737
+            private_ip='10.255.255.255',
+            location='Unit Test',
+            sns_endpoint='arn:aws:sns:ap-northeast-1:0:topic',
+            sns_access_key='mock',
+            sns_secret_key='mock',
+            is_active=True,
+        )
+
+    def test_node_init_snapshots_original(self):
+        """After loading a Node from DB, _original_* mirrors stored values."""
+        n = self._make_node()
+        loaded = models.Node.objects.get(pk=n.pk)
+        self.assertEqual(loaded._original_is_active, loaded.is_active)
+        self.assertEqual(loaded._original_public_ip, loaded.public_ip)
+
+    def test_node_save_refreshes_snapshot(self):
+        """After save(), _original_* must reflect the just-written values, not
+        the construction-time values. This is the core invariant the fix adds."""
+        n = self._make_node()
+        # Modify both tracked fields and save.
+        n.is_active = False
+        n.public_ip = '192.0.2.2'
+        n.save()
+        self.assertEqual(n._original_is_active, False,
+            '_original_is_active should be refreshed to the just-saved value')
+        self.assertEqual(n._original_public_ip, '192.0.2.2',
+            '_original_public_ip should be refreshed to the just-saved value')
+
+    def test_node_toggle_twice_on_same_instance_cascades_to_nodeaccount(self):
+        """The regression test for the change_ips_softly bug.
+
+        Toggling Node.is_active twice on the SAME in-memory instance must
+        cascade NodeAccount.is_active twice — once OFF, once back ON. The
+        bug pre-fix was that the second toggle's on_update() compared
+        against a stale construction-time _original and skipped the cascade.
+        """
+        node = self._make_node()
+        account = self._make_account('9001')
+        na = models.NodeAccount.objects.create(node=node, account=account, is_active=True)
+
+        # Step 1: simulate `node.toggle_active()` → deactivate.
+        node.is_active = False
+        node.save()
+        na.refresh_from_db()
+        self.assertFalse(na.is_active,
+            'first toggle should cascade NodeAccount.is_active to False')
+
+        # Step 2: simulate `node.toggle_active()` → reactivate, on the SAME instance.
+        node.is_active = True
+        node.save()
+        na.refresh_from_db()
+        self.assertTrue(na.is_active,
+            'second toggle on the same instance must also cascade — '
+            'this is the change_ips_softly regression we are guarding against')
+
+    def test_node_toggle_twice_respects_account_is_active(self):
+        """Cascade computes `new = node.is_active AND account.is_active`.
+        When the account is inactive, NodeAccount stays False even after
+        toggling the node back to active.
+        """
+        node = self._make_node()
+        account = self._make_account('9002')
+        account.is_active = False
+        account.save()
+        na = models.NodeAccount.objects.create(node=node, account=account, is_active=False)
+
+        node.is_active = False
+        node.save()
+        na.refresh_from_db()
+        self.assertFalse(na.is_active)
+
+        node.is_active = True
+        node.save()
+        na.refresh_from_db()
+        self.assertFalse(na.is_active,
+            'reactivating the node should NOT reactivate NodeAccount '
+            'when the underlying Account is inactive')
+
+    def test_node_no_change_no_cascade(self):
+        """Saving without changing is_active should not flip the
+        NodeAccount cascade (no spurious post_save side effects)."""
+        node = self._make_node()
+        account = self._make_account('9003')
+        na = models.NodeAccount.objects.create(node=node, account=account, is_active=True)
+
+        # Save with no change to is_active.
+        node.public_ip = '192.0.2.3'
+        node.save()
+        na.refresh_from_db()
+        self.assertTrue(na.is_active,
+            'a save that does not flip is_active should leave NodeAccount untouched')

--- a/shadowsocks_manager/shadowsocks/tests.py
+++ b/shadowsocks_manager/shadowsocks/tests.py
@@ -680,7 +680,7 @@ class ManagementCommandTestCase(AppTestCase):
         self.assertEqual(models.Config.load().cache_timeout, 99)
 
 
-class NodeOriginalSnapshotTestCase(BaseTestCase):
+class NodeOriginalSnapshotTestCase(AppTestCase):
     """
     Regression tests for the `_original_*` field-snapshot tracking on the
     Node model.


### PR DESCRIPTION
## Summary

Fix a silent race in `Node._original_*` snapshot tracking that breaks `Node.change_ips_softly()`'s step-5 reactivation when AWS Config event delivery is slower than the 60-second sleep window. Symptom: a successful EIP rotation leaves all NodeAccount rows on the rotated node permanently inactive, `port_heartbeat` (every 60s) keeps removing the users from the ss-manager, and end-to-end VPN service breaks until something else triggers a re-save of the NodeAccount rows (typically a manual admin click).

## The bug, walked through

```python
# Node model — pre-fix
def __init__(self, *args, **kwargs):
    super().__init__(*args, **kwargs)
    self._original_is_active = self.is_active   # captured ONCE
    self._original_public_ip = self.public_ip
```

`_original_is_active` is set in `__init__` and never refreshed by `save()`. `Node.on_update()` cascades to `NodeAccount.is_active` only when `_original_is_active != self.is_active`.

`Node.change_ips_softly()` does:

```python
for node in cls.objects.filter(is_active=True, ...):
    # __init__ ran when QuerySet yielded the instance → _original_is_active = True

    node.toggle_active()        # is_active=False
    # save(): on_update sees _original=True vs is_active=False
    #         → cascade NodeAccount.is_active=False  ✓

    time.sleep(300)
    node.change_ip()             # publish SNS → lambda swaps EIP
    time.sleep(60)               # hope AWS Config event arrives in this 60s window

    node.toggle_active()        # is_active=True
    # save(): on_update sees _original=True (STALE — set in __init__) vs is_active=True
    #         → no diff → no cascade  ✗  ← bug
```

Reactivation of NodeAccount only happens if the AWS Config event arrives **before** step 5 and runs the separate save chain via `LambdaSnsTopicSubscriber → NodeHandler → POST /shadowsocks/node/`. That handler loads a fresh Node instance (with `_original_is_active=False` reflecting step 1's write), sets `is_active=True`, and its save correctly fires the cascade.

When Config delivery is slow (cross-account SNS path can take 60–120s in production), step 5 runs first, writes `is_active=True` to the DB with no cascade, and then Config's handler also fires no cascade (because by then `_original` reflects DB which is already True). NodeAccount stays inactive forever.

## Fix

Extract the snapshot into `Node._snapshot_original()` called from both `__init__` and `save()`:

```python
def __init__(self, *args, **kwargs):
    super().__init__(*args, **kwargs)
    self._snapshot_original()

def _snapshot_original(self):
    self._original_is_active = self.is_active
    self._original_public_ip = self.public_ip

def save(self, *args, **kwargs):
    super().save(*args, **kwargs)
    self._snapshot_original()
```

Now a second `save()` on the same in-memory instance correctly compares against the just-written values, not the construction-time values. The toggle-twice pattern in `change_ips_softly` cascades on both toggles deterministically, independent of AWS Config event delivery timing.

## Same pattern on Account and SSManager — intentionally NOT touched

Account (`_original_username`, `_original_password`, `_original_is_active`) and SSManager (`_original_port`, `_original_server_edition`) share the same snapshot-once shape. Their save+save scenarios are not currently observed to trigger user-visible bugs, so they are not modified in this PR. If/when their bugs surface, the same `_snapshot_original()` shape can be lifted onto them in a follow-up.

## Tests

Five regression tests added to `shadowsocks/tests.py::NodeOriginalSnapshotTestCase`. None require `SSM_TEST_SS_MGR_*` env vars (they create Nodes/Accounts in test-isolated DB transactions, no real ssmanager needed):

| Test | What it locks in |
|---|---|
| `test_node_init_snapshots_original` | Sanity — fresh-loaded Node mirrors stored values |
| `test_node_save_refreshes_snapshot` | The fix's core invariant — `_original_*` reflects just-written values |
| `test_node_toggle_twice_on_same_instance_cascades_to_nodeaccount` | Direct regression — would have failed pre-fix |
| `test_node_toggle_twice_respects_account_is_active` | Cascade still respects `Account.is_active` |
| `test_node_no_change_no_cascade` | Saves that don't flip `is_active` don't flip NodeAccount |

## Discovered via

Production hit on a downstream deployment (Shadowsocks Manager hub for `aiview.com`). The nightly `change_ips_softly` celery beat task rotated EIPs successfully but left all NodeAccount rows on a node permanently inactive; `port_heartbeat` then kept removing the affected users from the ss-manager every 60s, breaking the VPN service end-to-end. The user manually reactivated NodeAccount rows in the admin to restore service.

Full postmortem (timing diagrams, CloudTrail trace, why it worked in the prior year's cluster, deployment-side mitigations) is in the deployment's `AIVIEW/NOTES/vpn-rotation-night-1-postmortem.md`. Sharing the summary here for posterity since the fix lives upstream.

## Test plan

- [ ] `ci-unittest` matrix (py3.10–3.14) green on this PR
- [ ] Coverage stable or up; the new tests cover a previously-uncovered code path in `Node.on_update` cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
