### PR TITLE
release: 0.1.21 — Django 3.2 + Python 3.14 BaseContext fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shadowsocks-manager"
-version = "0.1.17"
+version = "0.1.20"
 requires-python = ">=3.8"
 dependencies = [
     "future",
@@ -123,7 +123,7 @@ shadowsocks_manager = ["**/fixtures/*"]
 universal = true
 
 [tool.bumpversion]
-current_version = "0.1.17"
+current_version = "0.1.20"
 parse = """
     (?P<major>\\d+)\\.
     (?P<minor>\\d+)\\.

--- a/shadowsocks_manager/shadowsocks_manager/__init__.py
+++ b/shadowsocks_manager/shadowsocks_manager/__init__.py
@@ -6,5 +6,5 @@ from __future__ import absolute_import, unicode_literals
 from .celery import app as celery_app
 
 
-__version__ = "0.1.17"
+__version__ = "0.1.20"
 __build__ = ""

--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -13,8 +13,21 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 # py2.7 and py3 compatibility imports
 from __future__ import unicode_literals
 
+import sys
 import os
 from decouple import Config, RepositoryEnv
+
+# Django 3.2's BaseContext.__copy__ uses copy(super()), which breaks on Python 3.14+
+# because super() objects no longer have __dict__. Patch it before any template rendering.
+# Remove once Django is upgraded to 4.2+ (tracked in PR #42).
+if sys.version_info >= (3, 14):
+    from django.template.context import BaseContext
+    def _patched_base_context_copy(self):
+        duplicate = self.__class__.__new__(self.__class__)
+        duplicate.__dict__ = self.__dict__.copy()
+        duplicate.dicts = self.dicts[:]
+        return duplicate
+    BaseContext.__copy__ = _patched_base_context_copy
 
 from utils.version import get_version
 


### PR DESCRIPTION
## Summary
- Includes PR #47: monkey-patch for Django 3.2 BaseContext.__copy__ on Python 3.14
- Fixes admin UI 500 errors on all list views in the slim-latest Docker image (which runs Python 3.14)

## Discovered via
AIVIEW VPN production hub — admin UI threw 500 on every changelist view after the 2026 cluster rebuild on the slim Docker image (Python 3.14). PR #47 contains the monkey-patch; this PR releases it.