### PR TITLE
chore: add Dependabot version updates for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Enable Dependabot version updates for pip dependencies and GitHub Actions workflows. Weekly schedule, limit 5 open PRs for pip to reduce noise.

- **pip**: weekly, directory `/`, limit 5 open PRs, labeled `dependencies`
- **github-actions**: weekly, directory `/`, labeled `dependencies`