### PR TITLE
perf(celery): run worker with --pool=solo to cut ~100 MB RSS

### DIFF
--- a/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
+++ b/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
@@ -1,6 +1,10 @@
 [program:ssm-celery-worker]
 environment=%(ENV_SSM_ENV)s
-command=ssm-celery worker -l info
+; --pool=solo runs tasks in the worker process itself instead of forking a
+; prefork pool child, saving ~100 MB RSS (each child loads the full Django app).
+; Concurrency is effectively 1 either way for this single-node manager, so this
+; is a pure memory win with no change in task-execution behaviour.
+command=ssm-celery worker --pool=solo -l info
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true


### PR DESCRIPTION
## Summary
Run the celery worker with `--pool=solo` instead of the default prefork pool. The prefork pool forks a child process that loads the full Django app (~100 MB RSS on a live hub); for this single-node manager, concurrency is effectively 1 either way, so solo runs tasks in the worker process itself — **same execution behaviour, ~100 MB less memory**.

## Why
Measured on a production hub (t2.micro), the ssm container's 460 MB breaks down as:
- celery worker (master) **196 MB**
- celery prefork child **101 MB**  ← removed by `--pool=solo`
- celery beat **63 MB**
- uWSGI worker **100 MB** (already `processes=1`)

This is part of reducing the manager's footprint so it fits a smaller Graviton instance (t4g.micro) comfortably and relieves current swap pressure.

## Scope / safety
- **Behaviour unchanged**: solo executes one task at a time, identical to the current effective concurrency=1.
- **Beat left as a separate supervised program** (not embedded via `-B`). Embedding beat would save another ~63 MB but couples it to the worker — a worker restart could miss a scheduled tick (the nightly EIP rotation). Keeping beat separate preserves scheduling robustness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
