### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -22,7 +22,7 @@ jobs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get version
         id: get-version
         run: |
@@ -30,14 +30,14 @@ jobs:
           echo "VERSION=$version" >> $GITHUB_ENV
           echo "VERSION=$version" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -56,7 +56,7 @@ jobs:
       SSM_VERSION: ${{ needs.docker-build-and-push.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up git user
         run: |
           git config --global user.name "ci-docker.github-actions[bot]"
@@ -73,15 +73,14 @@ jobs:
       SSM_VERSION: ${{ needs.docker-build-and-push.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run Docker container
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_on: error
-          command: |
-            bash install.sh
+        run: |
+          for attempt in 1 2 3; do
+            timeout 180 bash install.sh && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 5 || exit 1
+          done
       - name: Verify container healthy
         run: |
           sleep 20

--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -36,7 +36,7 @@ jobs:
       RUN_HISTORY: ${{ steps.check-run.outputs.RUN_HISTORY }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check run history
         id: check-run
         env:
@@ -60,7 +60,7 @@ jobs:
           echo -e '#!/usr/bin/env bash\n' | sudo tee /usr/sbin/sendmail
           sudo chmod 755 /usr/sbin/sendmail
       - name: Set up Python for tox
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install tox
@@ -68,11 +68,11 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python for test ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run Django testcases
@@ -81,7 +81,7 @@ jobs:
           echo "UNDOTTED_PY_VERSION=${undotted_py_version}" >> $GITHUB_ENV
           tox run -e "py${undotted_py_version}"
       - name: Upload coverage data as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-py${{ env.UNDOTTED_PY_VERSION }}
           path: .tox/.coverage.py${{ env.UNDOTTED_PY_VERSION }}*
@@ -92,7 +92,7 @@ jobs:
     needs: unittest
     steps:
       - name: Set up Python for tox
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install tox
@@ -100,11 +100,11 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Download all coverage data from artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-py*
           path: .tox


### PR DESCRIPTION
## Summary

GitHub is dropping Node.js 20 runner support on **June 16, 2026** (9 days away). This PR updates all affected actions before the deadline.

**ci-docker.yml**
- `actions/checkout` v4 → v5
- `docker/setup-buildx-action` v3 → v4
- `docker/login-action` v3 → v4
- `docker/build-push-action` v5 → v6
- Replaced unmaintained `nick-invision/retry@v2` with an inline bash retry loop (`timeout 180 bash install.sh` × 3 attempts with 5s backoff) — removes the third-party dependency entirely

**ci-unittest.yml**
- `actions/checkout` v4 → v5
- `actions/setup-python` v5 → v6 (v6.2.0, released 2026-01-22)
- `actions/upload-artifact` v4 → v7 (also Node 24-ready; latest major)
- `actions/download-artifact` v4 → v8 (also Node 24-ready; latest major)

## Test plan

- [ ] Trigger `ci-unittest` workflow manually on this branch and verify all Python matrix jobs pass
- [ ] Verify no warnings about deprecated Node.js runtime in the workflow run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)