### PR TITLE
release: CI hardening + Celery memory optimisation (0.1.23)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -22,7 +22,7 @@ jobs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get version
         id: get-version
         run: |
@@ -30,14 +30,14 @@ jobs:
           echo "VERSION=$version" >> $GITHUB_ENV
           echo "VERSION=$version" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -56,7 +56,7 @@ jobs:
       SSM_VERSION: ${{ needs.docker-build-and-push.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up git user
         run: |
           git config --global user.name "ci-docker.github-actions[bot]"
@@ -73,15 +73,14 @@ jobs:
       SSM_VERSION: ${{ needs.docker-build-and-push.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run Docker container
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_on: error
-          command: |
-            bash install.sh
+        run: |
+          for attempt in 1 2 3; do
+            timeout 180 bash install.sh && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 5 || exit 1
+          done
       - name: Verify container healthy
         run: |
           sleep 20

--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -36,7 +36,7 @@ jobs:
       RUN_HISTORY: ${{ steps.check-run.outputs.RUN_HISTORY }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check run history
         id: check-run
         env:
@@ -60,7 +60,7 @@ jobs:
           echo -e '#!/usr/bin/env bash\n' | sudo tee /usr/sbin/sendmail
           sudo chmod 755 /usr/sbin/sendmail
       - name: Set up Python for tox
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install tox
@@ -68,11 +68,11 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python for test ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run Django testcases
@@ -81,7 +81,7 @@ jobs:
           echo "UNDOTTED_PY_VERSION=${undotted_py_version}" >> $GITHUB_ENV
           tox run -e "py${undotted_py_version}"
       - name: Upload coverage data as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-py${{ env.UNDOTTED_PY_VERSION }}
           path: .tox/.coverage.py${{ env.UNDOTTED_PY_VERSION }}*
@@ -92,7 +92,7 @@ jobs:
     needs: unittest
     steps:
       - name: Set up Python for tox
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install tox
@@ -100,11 +100,11 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Download all coverage data from artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-py*
           path: .tox

--- a/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
+++ b/deploy/supervisor/vendors/shadowsocks-manager-celery.conf
@@ -1,6 +1,10 @@
 [program:ssm-celery-worker]
 environment=%(ENV_SSM_ENV)s
-command=ssm-celery worker -l info
+; --pool=solo runs tasks in the worker process itself instead of forking a
+; prefork pool child, saving ~100 MB RSS (each child loads the full Django app).
+; Concurrency is effectively 1 either way for this single-node manager, so this
+; is a pure memory win with no change in task-execution behaviour.
+command=ssm-celery worker --pool=solo -l info
 umask=022
 user=%(ENV_SSM_USER)s
 redirect_stderr=true


### PR DESCRIPTION
Merges develop → master, shipping three independent improvements.

## What ships

- **Dependabot** (`chore/add-dependabot`): weekly automated PRs for pip deps and GitHub Actions versions
- **Celery `--pool=solo`** (`perf/celery-solo-pool`): removes the prefork child process, saving ~100 MB RSS on production (t2.micro measured: 460 MB → ~360 MB). Concurrency is effectively 1 either way for this single-node manager — pure memory win, no behaviour change.
- **GitHub Actions → Node.js 24** (`chore/actions-node24-upgrade`): bumps all workflow actions before the June 16, 2026 forced-migration deadline. Replaces unmaintained `nick-invision/retry@v2` with inline bash retry loop.

## After merge
Trigger `ci-pypi` to bump to 0.1.23 and publish to PyPI, then `ci-docker` to build images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)