### PR TITLE
fix(settings): map removed memcached.MemcachedCache to PyMemcacheCache

### DIFF
--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -297,6 +297,23 @@ LOGGING = {
 # Memcached
 
 CACHES_BACKEND = config('SSM_CACHES_BACKEND', default='locmem.LocMemCache')
+
+# Backward-compat: `memcached.MemcachedCache` (the python-memcached driver) was
+# removed in Django 4.1. Deployments upgraded in place from Django 3.x still have
+# `SSM_CACHES_BACKEND=memcached.MemcachedCache` persisted in their .ssm-env, which
+# would raise InvalidCacheBackendError on Django 5 and stop the manager booting.
+# Transparently map the dropped alias to the supported PyMemcacheCache driver so
+# existing deployments survive the upgrade without manual reconfiguration.
+if CACHES_BACKEND == 'memcached.MemcachedCache':
+    import warnings
+    warnings.warn(
+        "SSM_CACHES_BACKEND=memcached.MemcachedCache was removed in Django 4.1; "
+        "falling back to memcached.PyMemcacheCache. Set "
+        "SSM_CACHES_BACKEND=memcached.PyMemcacheCache to silence this warning.",
+        DeprecationWarning,
+    )
+    CACHES_BACKEND = 'memcached.PyMemcacheCache'
+
 MEMCACHED_HOST = config('SSM_MEMCACHED_HOST', default='localhost')
 MEMCACHED_PORT = config('SSM_MEMCACHED_PORT', default='11211')
 


### PR DESCRIPTION
## Problem
The Django 5.2 upgrade (#49) switched the memcached driver to `pymemcache` and supports `SSM_CACHES_BACKEND=memcached.PyMemcacheCache`. But **deployments upgraded in place from Django 3.x still have `SSM_CACHES_BACKEND=memcached.MemcachedCache` persisted in their `.ssm-env`** — and that backend was **removed in Django 4.1**. On Django 5 they raise `InvalidCacheBackendError` and the manager won't boot.

(Confirmed on the live aiview.com hub: its `.ssm-env` carries `SSM_CACHES_BACKEND=memcached.MemcachedCache`.)

## Fix
Transparently remap the dropped alias `memcached.MemcachedCache` → `memcached.PyMemcacheCache` (with a `DeprecationWarning`), so existing deployments survive the Django 5 image without manual env surgery. The `memcached.*` LOCATION wiring already added in #49 then applies normally.

## Note
This also matters for the cross-process `django-cache-lock` the EIP-rotation tasks use: it needs the **shared** memcached cache, so silently falling back to anything else (or failing to boot) would be worse than remapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
