### PR TITLE
Release: cache back-compat shim + CI Node.js 24 upgrade (→ 0.1.24)

### DIFF
--- a/.github/workflows/ci-pypi.yml
+++ b/.github/workflows/ci-pypi.yml
@@ -47,9 +47,9 @@ jobs:
           esac
           echo "VERSION_PART=$version_part" >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -88,27 +88,25 @@ jobs:
       NEW_VERSION: ${{ needs.pypi-py3-build-and-upload.outputs.NEW_VERSION }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install --upgrade pip
       - name: Install from binary distribution
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 6
-          max_attempts: 3
-          retry_on: error
-          command: |
-            pip install --only-binary shadowsocks-manager shadowsocks-manager==${{ env.NEW_VERSION }}
+        run: |
+          for attempt in 1 2 3; do
+            timeout 360 pip install --only-binary shadowsocks-manager shadowsocks-manager==${{ env.NEW_VERSION }} && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 5 || exit 1
+          done
       - name: Clean up for installing source distribution
         run: |
           pip list --exclude pip | awk 'NR>2 {print $1}' | xargs pip uninstall -y
       - name: Install from source distribution with PEP 517 required
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_on: error
-          command: |
-            pip install --use-pep517 --no-binary shadowsocks-manager shadowsocks-manager==${{ env.NEW_VERSION }}
+        run: |
+          for attempt in 1 2 3; do
+            timeout 180 pip install --use-pep517 --no-binary shadowsocks-manager shadowsocks-manager==${{ env.NEW_VERSION }} && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 5 || exit 1
+          done

--- a/.github/workflows/ci-testpypi.yml
+++ b/.github/workflows/ci-testpypi.yml
@@ -1,6 +1,6 @@
 name: ci-testpypi
 
-# This workflow bumps the version of the package (without commit and tag), 
+# This workflow bumps the version of the package (without commit and tag),
 # builds and uploads the package to TestPyPI,
 # and tests the installation under py3 from TestPyPI.
 #
@@ -34,7 +34,7 @@ jobs:
       RUN_HISTORY: ${{ steps.check-run.outputs.RUN_HISTORY }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check run history
         id: check-run
         env:
@@ -56,9 +56,9 @@ jobs:
       NEW_VERSION: ${{ steps.bump-version.outputs.NEW_VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -84,9 +84,9 @@ jobs:
       - name: Upload to TestPyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN }}        
+          TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN }}
         run: twine upload --repository testpypi dist/*
-    
+
   testpypi-py3-install:
     runs-on: ubuntu-latest
     needs: testpypi-py3-build-and-upload
@@ -98,7 +98,7 @@ jobs:
       NEW_VERSION: ${{ needs.testpypi-py3-build-and-upload.outputs.NEW_VERSION }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -108,23 +108,21 @@ jobs:
       - name: Install from binary distribution
         env:
           PIP_INDEX_URL: https://test.pypi.org/simple/
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 6
-          max_attempts: 3
-          retry_on: error
-          command: |
-            pip install --no-deps --only-binary ${{ env.PROJECT_NAME_FOR_TESTPYPI }} ${{ env.PROJECT_NAME_FOR_TESTPYPI }}==${{ env.NEW_VERSION }}
+        run: |
+          for attempt in 1 2 3; do
+            timeout 360 pip install --no-deps --only-binary ${{ env.PROJECT_NAME_FOR_TESTPYPI }} ${{ env.PROJECT_NAME_FOR_TESTPYPI }}==${{ env.NEW_VERSION }} && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 5 || exit 1
+          done
       - name: Clean up for installing source distribution
         run: |
           pip uninstall -y ${{ env.PROJECT_NAME_FOR_TESTPYPI }}
       - name: Install from source distribution with setuptools and wheel required
         env:
           PIP_INDEX_URL: https://test.pypi.org/simple/
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_on: error
-          command: |
-            pip install --no-build-isolation --no-deps --no-binary ${{ env.PROJECT_NAME_FOR_TESTPYPI }} ${{ env.PROJECT_NAME_FOR_TESTPYPI }}==${{ env.NEW_VERSION }}
+        run: |
+          for attempt in 1 2 3; do
+            timeout 180 pip install --no-build-isolation --no-deps --no-binary ${{ env.PROJECT_NAME_FOR_TESTPYPI }} ${{ env.PROJECT_NAME_FOR_TESTPYPI }}==${{ env.NEW_VERSION }} && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 5 || exit 1
+          done

--- a/shadowsocks_manager/shadowsocks_manager/settings.py
+++ b/shadowsocks_manager/shadowsocks_manager/settings.py
@@ -297,6 +297,23 @@ LOGGING = {
 # Memcached
 
 CACHES_BACKEND = config('SSM_CACHES_BACKEND', default='locmem.LocMemCache')
+
+# Backward-compat: `memcached.MemcachedCache` (the python-memcached driver) was
+# removed in Django 4.1. Deployments upgraded in place from Django 3.x still have
+# `SSM_CACHES_BACKEND=memcached.MemcachedCache` persisted in their .ssm-env, which
+# would raise InvalidCacheBackendError on Django 5 and stop the manager booting.
+# Transparently map the dropped alias to the supported PyMemcacheCache driver so
+# existing deployments survive the upgrade without manual reconfiguration.
+if CACHES_BACKEND == 'memcached.MemcachedCache':
+    import warnings
+    warnings.warn(
+        "SSM_CACHES_BACKEND=memcached.MemcachedCache was removed in Django 4.1; "
+        "falling back to memcached.PyMemcacheCache. Set "
+        "SSM_CACHES_BACKEND=memcached.PyMemcacheCache to silence this warning.",
+        DeprecationWarning,
+    )
+    CACHES_BACKEND = 'memcached.PyMemcacheCache'
+
 MEMCACHED_HOST = config('SSM_MEMCACHED_HOST', default='localhost')
 MEMCACHED_PORT = config('SSM_MEMCACHED_PORT', default='11211')
 


### PR DESCRIPTION
Release `develop → master`. `ci-pypi` will bump `0.1.23 → 0.1.24` post-merge.

## What ships
- **#59** — `fix(settings)`: map removed `memcached.MemcachedCache` → `memcached.PyMemcacheCache` (Django 4.1 removed the old backend). Back-compat shim so old `.ssm-env` files don't break boot on Django 5. (`slim-latest`/0.1.23 already defaults to PyMemcacheCache, so this is defense-in-depth for other deployments.)
- **#60** — `ci`: upgrade GitHub Actions to Node.js 24-compatible versions (checkout/setup-python/retry) ahead of GitHub's 2026-06-16 Node 20 cutoff.

## Diff gate
Reviewed `git log master..develop` — exactly the two changes above; no stray commits. CI green on develop (`26b1f79`), dry-merge conflict-free (master keeps its `0.1.23` version line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)