### PR TITLE
feat(shadowsocks): Shadowsocks-2022 support via the rust server edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,39 @@ Shadowsocks Accounts` and assign the existing nodes to them.
     After a few seconds, the created user ports should be available to your
 Shadowsocks client.
 
+### 3.1. Shadowsocks-2022 (SS-2022) with the rust edition
+
+The classic ciphers above run on the `libev` server edition. shadowsocks-libev does
+**not** implement the Shadowsocks-2022 (SIP022 AEAD-2022) ciphers
+(`2022-blake3-aes-256-gcm` and friends), which are highly censorship-resistant.
+
+For SS-2022, use the `rust` server edition, backed by the
+[alexzhangs/shadowsocks-rust](https://github.com/alexzhangs/shadowsocks-rust) image. Its
+`ssmanager` speaks the same multi-user Manager API, so everything else works unchanged.
+
+1. Run the rust manager instead of the libev one:
+
+    ```sh
+    MGR_PORT=6001
+    ENCRYPT=2022-blake3-aes-256-gcm
+    docker run -d -p $MGR_PORT:$MGR_PORT/UDP \
+        --network ssm-network --name ssm-ss-rust alexzhangs/shadowsocks-rust \
+        ssmanager --manager-address 0.0.0.0:$MGR_PORT -m $ENCRYPT -s 0.0.0.0 -U
+    ```
+
+2. Add the Node, then on its Shadowsocks Manager set **Server edition** to `rust` and
+**Encrypt** to a SS-2022 method (e.g. `2022-blake3-aes-256-gcm`).
+
+3. Create accounts as usual. For SS-2022 the account **password must be a Base64 PSK** of
+the cipher's key size (32 bytes for the `aes-256`/`chacha20` methods, 16 bytes for
+`aes-128`). Select the accounts and run the admin action **"Generate Shadowsocks-2022
+password (PSK)"** to fill conforming PSKs automatically; the portal also rejects a
+non-conforming password for a SS-2022 node with a clear error.
+
+When deploying through [aws-cfn-vpn](https://github.com/alexzhangs/aws-cfn-vpn), set the
+stack parameter `SSEdition=rust` together with a SS-2022 `SSEncrypt` value, and the node
+provisions and self-registers as a rust/SS-2022 node automatically.
+
 
 ## 4. Sendmail (Optional)
 

--- a/shadowsocks_manager/shadowsocks/admin.py
+++ b/shadowsocks_manager/shadowsocks/admin.py
@@ -9,6 +9,7 @@ from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 from admin_lazy_load import LazyLoadAdminMixin
 
+from . import ciphers
 from .models import Config, Node, Account, NodeAccount, SSManager
 
 
@@ -219,5 +220,21 @@ class AccountAdmin(ImportExportModelAdmin):
 
     add_all_nodes.short_description = 'Add All Nodes to Selected Shadowsocks Accounts'
 
-    actions = (toggle_active, notify, add_all_nodes,)
+    def generate_ss2022_password(self, request, queryset):
+        for obj in queryset:
+            # Use the cipher of an assigned Shadowsocks-2022 node if there is one,
+            # otherwise default to the recommended 32-byte 2022-blake3-aes-256-gcm.
+            method = '2022-blake3-aes-256-gcm'
+            for na in obj.nodes_ref.all():
+                ssmanager = na.node.ssmanager
+                if ssmanager and ciphers.is_2022(ssmanager.encrypt):
+                    method = ssmanager.encrypt
+                    break
+            obj.password = ciphers.generate_password(method)
+            obj.save()
+            messages.info(request, '{}: generated a {} PSK.'.format(obj, method))
+
+    generate_ss2022_password.short_description = 'Generate Shadowsocks-2022 password (PSK) for Selected Shadowsocks Accounts'
+
+    actions = (toggle_active, notify, add_all_nodes, generate_ss2022_password,)
     resource_class = AccountResource

--- a/shadowsocks_manager/shadowsocks/ciphers.py
+++ b/shadowsocks_manager/shadowsocks/ciphers.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+Shadowsocks cipher (encrypt method) metadata and helpers.
+
+Single source of truth for:
+  * which methods are Shadowsocks-2022 (SIP022 AEAD-2022) ciphers and their key sizes
+  * generating a conforming password for a method
+  * validating that a password conforms to a method
+
+For SS-2022 ciphers the password MUST be a Base64-encoded key (PSK) of exactly the
+cipher's key size; arbitrary passwords are rejected by the server. shadowsocks-libev
+does not implement the SS-2022 ciphers -- they require the `rust` server edition
+(shadowsocks-rust), see https://github.com/alexzhangs/shadowsocks-rust .
+"""
+
+import os
+import base64
+
+# SS-2022 (SIP022) methods -> required key size in bytes.
+AEAD_2022_METHODS = {
+    '2022-blake3-aes-128-gcm': 16,
+    '2022-blake3-aes-256-gcm': 32,
+    '2022-blake3-chacha20-poly1305': 32,
+}
+
+# Length for legacy (non-2022) random passwords.
+DEFAULT_PASSWORD_LENGTH = 16
+
+
+def is_2022(method):
+    """Return True if `method` is a Shadowsocks-2022 (SIP022) cipher."""
+    return method in AEAD_2022_METHODS
+
+
+def key_size(method):
+    """Return the required key size in bytes for a SS-2022 `method`, else None."""
+    return AEAD_2022_METHODS.get(method)
+
+
+def generate_password(method=None):
+    """
+    Generate a password suitable for `method`.
+
+    For SS-2022 ciphers, returns a Base64-encoded random key (PSK) of exactly the
+    cipher's key size -- equivalent to `ssservice genkey -m <method>`. For any other
+    method (or None), returns a random alphanumeric string.
+    """
+    size = key_size(method)
+    if size is not None:
+        return base64.b64encode(os.urandom(size)).decode('ascii')
+
+    import random
+    import string
+    return ''.join(random.choices(string.ascii_letters + string.digits,
+                                  k=DEFAULT_PASSWORD_LENGTH))
+
+
+def is_valid_password(method, password):
+    """
+    Return True if `password` is valid for `method`.
+
+    For SS-2022 ciphers, the password must be a Base64 string that decodes to exactly
+    the cipher's key size. For any other method, any non-empty password is accepted.
+    """
+    size = key_size(method)
+    if size is None:
+        return bool(password)
+    try:
+        raw = base64.b64decode(password, validate=True)
+    except Exception:
+        return False
+    return len(raw) == size

--- a/shadowsocks_manager/shadowsocks/models.py
+++ b/shadowsocks_manager/shadowsocks/models.py
@@ -26,6 +26,8 @@ from dynamicmethod.models import DynamicMethodModel
 from notification.models import Template, Notify
 from domain.models import Record
 
+from . import ciphers
+
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +121,20 @@ class Account(User, StatisticMethod):
         if int(self.username) not in list(range(config.port_begin, config.port_end + 1)):
             raise ValidationError(_('Port number must be in the range of Config: '
                 'port_begin(%s) and port_end(%s)' % (config.port_begin, config.port_end)))
+
+        # For accounts assigned to any node using a Shadowsocks-2022 cipher, the
+        # password must be a valid Base64 PSK of that cipher's key size; otherwise
+        # the rust server silently rejects the port. Validate here for a clear error.
+        # (Only enforceable once the account is saved and has node assignments.)
+        if self.pk:
+            for na in self.nodes_ref.all():
+                ssmanager = na.node.ssmanager
+                if ssmanager and ciphers.is_2022(ssmanager.encrypt) \
+                        and not ciphers.is_valid_password(ssmanager.encrypt, self.password):
+                    raise ValidationError({'password': [_('Node "%s" uses the Shadowsocks-2022 '
+                        'cipher "%s"; the password must be a Base64 key of %s bytes. Use the '
+                        '"Generate Shadowsocks-2022 password" account action.'
+                        % (na.node.name, ssmanager.encrypt, ciphers.key_size(ssmanager.encrypt)))]})
 
     def save(self, *args, **kwargs):
         ret = super(Account, self).save(*args, **kwargs)
@@ -542,10 +558,12 @@ class InterfaceList(enum.Enum):
 class ServerEditionList(enum.Enum):
     LIBEV = 1
     PYTHON = 2
+    RUST = 3
 
     __labels__ = {
         LIBEV: "libev",
         PYTHON: "python",
+        RUST: "rust",
     }
 
 
@@ -561,9 +579,12 @@ class SSManager(models.Model):
             'aes-128-cfb, aes-192-cfb, aes-256-cfb, aes-128-ctr, aes-192-ctr, aes-256-ctr, '
             'camellia-128-cfb, camellia-192-cfb, camellia-256-cfb, bf-cfb, chacha20-ietf-poly1305, '
             'xchacha20-ietf-poly1305, salsa20, chacha20 and chacha20-ietf. '
+            'Shadowsocks-2022 ciphers (require the rust server edition): '
+            '2022-blake3-aes-128-gcm, 2022-blake3-aes-256-gcm, 2022-blake3-chacha20-poly1305. '
             'The changes made here will not affect the plugin status on server.')
     server_edition = enum.EnumField(ServerEditionList, default=ServerEditionList.LIBEV,
-        help_text='The Shadowsocks server edition. The libev edition is recommended.')
+        help_text='The Shadowsocks server edition. The libev edition is recommended for the '
+            'classic ciphers; the rust edition is required for the Shadowsocks-2022 ciphers.')
     is_v2ray_enabled = models.BooleanField(default=False,
         help_text='Whether the v2ray-plugin is enabled for Shadowsocks server. The changes made here will not '
             'affect the plugin status on server.')
@@ -586,6 +607,10 @@ class SSManager(models.Model):
             raise ValidationError({
                 self.node.get_ip_field_by_interface(self.interface):
                 [_('There is no IP address set for selected interface on the node.')]})
+        # Shadowsocks-2022 ciphers are only implemented by the rust server edition.
+        if ciphers.is_2022(self.encrypt) and self.server_edition != ServerEditionList.RUST:
+            raise ValidationError({'encrypt': [_('The Shadowsocks-2022 cipher "%s" requires the '
+                'rust server edition.' % self.encrypt)]})
 
     @property
     def _ip(self):
@@ -664,10 +689,10 @@ class SSManager(models.Model):
         """
         Manager API command: `list`.
         List all users with password.
-        Works only for libev edition.
+        Works for the libev and rust editions.
         This is an undocumented Shadowsocks Manager Command, but works.
         """
-        if self.server_edition == ServerEditionList.LIBEV:
+        if self.server_edition in (ServerEditionList.LIBEV, ServerEditionList.RUST):
             command = 'list'
             return self.call(command, read=True)
 
@@ -779,7 +804,9 @@ class SSManager(models.Model):
         """
         items = self.list_ex()
         if isinstance(items, list):
-            return any(item['server_port'] == str(port) for item in items)
+            # libev returns server_port as a string ("8381"); rust returns it as an
+            # integer (8381). Compare as strings so both editions match.
+            return any(str(item['server_port']) == str(port) for item in items)
         else:
             return None
 

--- a/shadowsocks_manager/shadowsocks/tests.py
+++ b/shadowsocks_manager/shadowsocks/tests.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import
 import json
 import os
 import time
+import base64
+import unittest
 import botocore
 from abc import abstractmethod
 from django.test import TestCase
@@ -16,7 +18,7 @@ from django.core.management import call_command
 from domain.models import Record
 from domain.tests import AppTestCase as DomainAppTestCase
 from notification.tests import AppTestCase as NotificationAppTestCase
-from shadowsocks import models, serializers
+from shadowsocks import models, serializers, ciphers
 
 
 import logging
@@ -57,12 +59,21 @@ The following environment variables are required to run some of the tests:
     The service requires the shadowsocks-libev edition rather than the shadowsocks-python edition.
 
 
+  * SSM_TEST_SS_MGR_RUST=1          # run the tests against a shadowsocks-rust ssmanager (SS-2022)
+
+    The rust ssmanager should be running outside the tests, e.g.:
+    * ssmanager --manager-address 127.0.0.1:$SSM_TEST_SS_MGR_RUST_PORT -m 2022-blake3-aes-256-gcm -s 127.0.0.1 -U
+    See the alexzhangs/shadowsocks-rust image; tox.ini launches it automatically.
+
+
 The following environment variables are optional used to override the default values:
 
   * SSM_TEST_SS_MGR_PRIVATE_IP      # The private ip address of the ss-manager.
   * SSM_TEST_SS_MGR_PORT            # The port number of the ss-manager.
   * SSM_TEST_SS_PORT_BEGIN          # The beginning port number of the shadowsocks-libev edition manager.
   * SSM_TEST_SS_PORT_END            # The ending port number of the shadowsocks-libev edition manager.
+  * SSM_TEST_SS_MGR_RUST_PORT       # The port number of the rust ssmanager (default 6004).
+  * SSM_TEST_SS_2022_METHOD         # The SS-2022 cipher to test (default 2022-blake3-aes-256-gcm).
 
 
 Feature matrix for methods in unittest.TestCase class:
@@ -103,6 +114,14 @@ SS_MGR_PRIVATE_IP = os.getenv('SSM_TEST_SS_MGR_PRIVATE_IP') or get_private_ip()
 SS_MGR_PORT = os.getenv('SSM_TEST_SS_MGR_PORT')
 SS_PORT_BEGIN = os.getenv('SSM_TEST_SS_PORT_BEGIN')
 SS_PORT_END = os.getenv('SSM_TEST_SS_PORT_END')
+
+# Shadowsocks-2022 (rust edition) end-to-end tests. Enabled when a rust ssmanager
+# is running outside the tests (see tox.ini), e.g.:
+#   ssmanager --manager-address 127.0.0.1:$SSM_TEST_SS_MGR_RUST_PORT \
+#       -m 2022-blake3-aes-256-gcm -s 127.0.0.1 -U
+SS_MGR_RUST = os.getenv('SSM_TEST_SS_MGR_RUST')
+SS_MGR_RUST_PORT = os.getenv('SSM_TEST_SS_MGR_RUST_PORT')
+SS_2022_METHOD = os.getenv('SSM_TEST_SS_2022_METHOD') or '2022-blake3-aes-256-gcm'
 
 
 class BaseTestCase(TestCase):
@@ -816,3 +835,144 @@ class NodeOriginalSnapshotTestCase(AppTestCase):
         na.refresh_from_db()
         self.assertTrue(na.is_active,
             'a save that does not flip is_active should leave NodeAccount untouched')
+
+
+class CiphersTestCase(TestCase):
+    """
+    Unit tests for the shadowsocks.ciphers helpers (no DB or server needed).
+    """
+
+    def test_is_2022(self):
+        self.assertTrue(ciphers.is_2022('2022-blake3-aes-256-gcm'))
+        self.assertTrue(ciphers.is_2022('2022-blake3-aes-128-gcm'))
+        self.assertTrue(ciphers.is_2022('2022-blake3-chacha20-poly1305'))
+        self.assertFalse(ciphers.is_2022('aes-256-gcm'))
+        self.assertFalse(ciphers.is_2022(''))
+        self.assertFalse(ciphers.is_2022(None))
+
+    def test_key_size(self):
+        self.assertEqual(ciphers.key_size('2022-blake3-aes-128-gcm'), 16)
+        self.assertEqual(ciphers.key_size('2022-blake3-aes-256-gcm'), 32)
+        self.assertEqual(ciphers.key_size('2022-blake3-chacha20-poly1305'), 32)
+        self.assertIsNone(ciphers.key_size('aes-256-gcm'))
+
+    def test_generate_password_2022_lengths(self):
+        for method, size in ciphers.AEAD_2022_METHODS.items():
+            pw = ciphers.generate_password(method)
+            raw = base64.b64decode(pw, validate=True)
+            self.assertEqual(len(raw), size, method)
+            # generated PSK must validate for its own method
+            self.assertTrue(ciphers.is_valid_password(method, pw), method)
+
+    def test_generate_password_legacy(self):
+        pw = ciphers.generate_password('aes-256-gcm')
+        self.assertEqual(len(pw), ciphers.DEFAULT_PASSWORD_LENGTH)
+        self.assertTrue(pw.isalnum())
+        pw_none = ciphers.generate_password(None)
+        self.assertEqual(len(pw_none), ciphers.DEFAULT_PASSWORD_LENGTH)
+
+    def test_is_valid_password(self):
+        method = '2022-blake3-aes-256-gcm'
+        # right size
+        self.assertTrue(ciphers.is_valid_password(method, base64.b64encode(b'0' * 32).decode()))
+        # wrong size (16 bytes for a 32-byte method)
+        self.assertFalse(ciphers.is_valid_password(method, base64.b64encode(b'0' * 16).decode()))
+        # not base64
+        self.assertFalse(ciphers.is_valid_password(method, 'not!base64!'))
+        # legacy method accepts any non-empty password
+        self.assertTrue(ciphers.is_valid_password('aes-256-gcm', 'anything'))
+        self.assertFalse(ciphers.is_valid_password('aes-256-gcm', ''))
+
+
+@unittest.skipUnless(SS_MGR_RUST == '1',
+    'set SSM_TEST_SS_MGR_RUST=1 with a running rust ssmanager to enable')
+class SSManagerRust2022TestCase(AppTestCase):
+    """
+    End-to-end tests against a real shadowsocks-rust `ssmanager` running a
+    Shadowsocks-2022 cipher (alexzhangs/shadowsocks-rust image). Validates that the
+    Django Manager-API client (add/list/remove/ping) drives the rust edition the same
+    way it drives libev, and that SS-2022 PSKs round-trip.
+    """
+
+    NODE_NAME = 'ss-rust-localhost'
+
+    @classmethod
+    def up(cls):
+        node = models.Node(
+            name=cls.NODE_NAME,
+            record=None,
+            public_ip='127.0.0.1',
+            private_ip='127.0.0.1',
+            location='Local',
+            is_active=True,
+        )
+        node.save()
+        ssmanager = models.SSManager(
+            node=node,
+            interface=models.InterfaceList.LOCALHOST,
+            encrypt=SS_2022_METHOD,
+            server_edition=models.ServerEditionList.RUST,
+            is_v2ray_enabled=False,
+        )
+        if SS_MGR_RUST_PORT:
+            ssmanager.port = int(SS_MGR_RUST_PORT)
+        ssmanager.save()
+
+    @classmethod
+    def setUpTestData(cls):
+        # Isolated: only this case's node/manager, not the shared allup() set.
+        cls.up()
+
+    def _mgr(self):
+        return models.SSManager.objects.get(node__name=self.NODE_NAME)
+
+    def test_rust_ssmanager_is_accessible(self):
+        self.assertTrue(self._mgr().is_accessible)
+
+    def test_rust_ssmanager_add_list_remove_with_psk(self):
+        obj = self._mgr()
+        port = 8391
+        psk = ciphers.generate_password(SS_2022_METHOD)
+        obj.add(port, psk)
+        # is_port_created() goes through the `list` Manager-API command and exercises
+        # the rust(int)-vs-libev(str) server_port comparison fix.
+        self.assertTrue(obj.is_port_created(port))
+        self.assertTrue(obj.is_port_created_or_accessible(port))
+        # the PSK we sent must come back verbatim in `list`
+        listed = {str(item['server_port']): item['password'] for item in obj.list()}
+        self.assertEqual(listed.get(str(port)), psk)
+
+        obj.remove(port)
+        self.assertFalse(obj.is_port_created(port))
+
+    def test_rust_ssmanager_edition_string(self):
+        self.assertEqual(
+            str(models.ServerEditionList.label(self._mgr().server_edition)), 'rust')
+
+    def test_2022_cipher_requires_rust_edition(self):
+        # A 2022 cipher on a non-rust edition must fail validation.
+        bad = models.SSManager(
+            node=self._mgr().node,
+            interface=models.InterfaceList.LOCALHOST,
+            encrypt=SS_2022_METHOD,
+            server_edition=models.ServerEditionList.LIBEV,
+        )
+        self.assertRaises(ValidationError, bad.clean)
+
+    def test_account_psk_validation_on_2022_node(self):
+        # An account assigned to a 2022 node must carry a valid Base64 PSK.
+        node = self._mgr().node
+        config = models.Config.load()
+        acc = models.Account(username=str(config.port_begin))  # in the configured port range
+        acc.password = 'not-a-valid-psk'
+        acc.save()
+        # is_active=False so creating the link does not try to add to the live server.
+        models.NodeAccount.objects.create(node=node, account=acc, is_active=False)
+        acc.refresh_from_db()
+
+        # invalid (non-PSK) password on a 2022 node must fail clean()
+        self.assertRaises(ValidationError, acc.clean)
+
+        # a conforming PSK passes clean()
+        acc.password = ciphers.generate_password(SS_2022_METHOD)
+        acc.clean()

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,9 @@ allowlist_externals = docker, test, bash
 set_env =
     DOCKER_SS_IMAGE = shadowsocks/shadowsocks-libev:edge
     DOCKER_SS_ENTRYPOINT_CMD = ss-manager --manager-address 0.0.0.0:6001 --executable /usr/local/bin/ss-server -m aes-256-gcm -s 0.0.0.0 -u
-    DOCKER_CLEANUP_CMD = bash -c 'echo Cleaning up existing Docker containers ...; declare name; for name in ssm-{envname}-memcached ssm-{envname}-rabbitmq ssm-{envname}-ss-libev-localhost ssm-{envname}-ss-libev-private; do docker ps --all --format {{.Names}} | grep -q $name && docker rm -fv $name || :; done'
+    DOCKER_SS_RUST_IMAGE = {env:SSM_TEST_SS_RUST_IMAGE:alexzhangs/shadowsocks-rust:latest}
+    DOCKER_SS_RUST_ENTRYPOINT_CMD = ssmanager --manager-address 0.0.0.0:6001 -m 2022-blake3-aes-256-gcm -s 0.0.0.0 -U
+    DOCKER_CLEANUP_CMD = bash -c 'echo Cleaning up existing Docker containers ...; declare name; for name in ssm-{envname}-memcached ssm-{envname}-rabbitmq ssm-{envname}-ss-libev-localhost ssm-{envname}-ss-libev-private ssm-{envname}-ss-rust-localhost; do docker ps --all --format {{.Names}} | grep -q $name && docker rm -fv $name || :; done'
 commands_pre =
     test -n CACHES_BACKEND -a -n "{env:CACHES_BACKEND}"
     test -n MEMCACHED_PORT -a -n "{env:MEMCACHED_PORT}"
@@ -88,6 +90,10 @@ pass_env =
     SSM_TEST_SS_MGR_PORT
     SSM_TEST_SS_PORT_BEGIN
     SSM_TEST_SS_PORT_END
+    SSM_TEST_SS_MGR_RUST
+    SSM_TEST_SS_MGR_RUST_PORT
+    SSM_TEST_SS_2022_METHOD
+    SSM_TEST_SS_RUST_IMAGE
 set_env =
     {[testenv]set_env}
     SSM_DATA_HOME = {envtmpdir}/ssm-data-home
@@ -96,6 +102,9 @@ set_env =
     SSM_TEST_SS_MGR_PORT = {env:SSM_TEST_SS_MGR_PORT:6002}
     SSM_TEST_SS_PORT_BEGIN = {env:SSM_TEST_SS_PORT_BEGIN:8391}
     SSM_TEST_SS_PORT_END = {env:SSM_TEST_SS_PORT_END:8395}
+    SSM_TEST_SS_MGR_RUST = {env:SSM_TEST_SS_MGR_RUST:1}
+    SSM_TEST_SS_MGR_RUST_PORT = {env:SSM_TEST_SS_MGR_RUST_PORT:6004}
+    SS_MGR_RUST_PORT = {env:SSM_TEST_SS_MGR_RUST_PORT:6004}
     CACHES_BACKEND = {env:SSM_TEST_CACHES_BACKEND:memcached.PyMemcacheCache}
     MEMCACHED_PORT = {env:SSM_TEST_MEMCACHED_PORT:11212}
     RABBITMQ_PORT = {env:SSM_TEST_RABBITMQ_PORT:5673}
@@ -103,6 +112,11 @@ set_env =
     SS_PORTS={env:SSM_TEST_SS_PORT_BEGIN:8391}-{env:SSM_TEST_SS_PORT_END:8395}
     COVERAGE_PROCESS_START = {toxinidir}{/}pyproject.toml
     COVERAGE_FILE = {toxworkdir}{/}.coverage.{envname}
+commands_pre =
+    {[testenv]commands_pre}
+    docker run -d -p 127.0.0.1:{env:SS_MGR_RUST_PORT}:6001/UDP \
+        --name ssm-{envname}-ss-rust-localhost {env:DOCKER_SS_RUST_IMAGE} {env:DOCKER_SS_RUST_ENTRYPOINT_CMD}
+    docker ps --all --filter name=ssm-{envname}-ss-rust-localhost
 commands =
     {[testenv]commands}
     bash -c 'test -n "{env:COVERAGE_FILE}" && rm -f {env:COVERAGE_FILE}.*'


### PR DESCRIPTION
## Summary

Adds **Shadowsocks-2022 (SIP022 AEAD-2022)** support (e.g. `2022-blake3-aes-256-gcm`), which shadowsocks-libev does not implement.

shadowsocks-rust's `ssmanager` speaks the **same UDP multi-user Manager API** as libev's `ss-manager`, so SS-2022 is a drop-in **server-edition swap** at the node plus small portal changes — no rewrite of the Django↔node control plane.

## Changes
- `ServerEditionList.RUST` server edition.
- New `shadowsocks/ciphers.py`: SS-2022 cipher key sizes, PSK generation (Base64 key == `ssservice genkey`) and validation.
- `SSManager`: list SS-2022 ciphers in help text; enable the `list` Manager-API command for rust; `clean()` requires the rust edition for SS-2022 ciphers.
- `is_port_created`: compare `server_port` as strings — libev returns a string, **rust returns an integer** (found via e2e).
- `Account.clean()`: require a valid Base64 PSK for accounts on SS-2022 nodes (clear error vs. silent server reject).
- `AccountAdmin`: "Generate Shadowsocks-2022 password (PSK)" action.
- Tests: `CiphersTestCase` (unit) + `SSManagerRust2022TestCase` (e2e against the new [alexzhangs/shadowsocks-rust](https://github.com/alexzhangs/shadowsocks-rust) image); `tox.ini` launches the rust container.
- README: rust edition / SS-2022 setup + `SSEdition` deploy param.

## Testing
- `CiphersTestCase` + `SSManagerRust2022TestCase` + `SSManagerTestCase` (libev regression) all green against real libev + rust ssmanager containers + memcached.
- Image-level data path verified: sslocal → ss-2022 server → origin.

Pairs with [alexzhangs/shadowsocks-rust](https://github.com/alexzhangs/shadowsocks-rust) and aws-cfn-vpn `SSEdition=rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)